### PR TITLE
Guard console logs in auth middleware

### DIFF
--- a/backend/middleware/adminAuth.js
+++ b/backend/middleware/adminAuth.js
@@ -1,15 +1,21 @@
 const jwt = require('jsonwebtoken');
 require('dotenv').config();
 
+const log = (...args) => {
+  if (process.env.NODE_ENV !== 'production') {
+    console.log(...args);
+  }
+};
+
 const JWT_SECRET = process.env.JWT_SECRET;
 
 module.exports = (req, res, next) => {
-  console.log('=== Admin Auth Middleware ===');
-  console.log('Request path:', req.path);
+  log('=== Admin Auth Middleware ===');
+  log('Request path:', req.path);
   
   const token = req.cookies.adminToken;
   
-  console.log('Admin token from cookies:', token ? 'Found' : 'Not found');
+  log('Admin token from cookies:', token ? 'Found' : 'Not found');
   
   if (!token) {
     return res.status(401).json({ msg: '管理者トークンがありません、認証が拒否されました' });
@@ -17,7 +23,7 @@ module.exports = (req, res, next) => {
 
   try {
     const decoded = jwt.verify(token, JWT_SECRET);
-    console.log('Admin token verified successfully:', decoded.admin.id);
+    log('Admin token verified successfully:', decoded.admin.id);
     req.admin = decoded.admin;
     next();
   } catch (err) {

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -2,17 +2,23 @@ const jwt = require('jsonwebtoken');
 const jwtBlacklist = require('../utils/jwtBlacklist');
 require('dotenv').config();
 
+const log = (...args) => {
+  if (process.env.NODE_ENV !== 'production') {
+    console.log(...args);
+  }
+};
+
 const JWT_SECRET = process.env.JWT_SECRET;
 
 module.exports = (req, res, next) => {
-  console.log('=== Auth Middleware ===');
-  console.log('Request path:', req.path);
-  console.log('Request headers:', JSON.stringify(req.headers, null, 2));
-  console.log('All cookies:', JSON.stringify(req.cookies, null, 2));
+  log('=== Auth Middleware ===');
+  log('Request path:', req.path);
+  log('Request headers:', JSON.stringify(req.headers, null, 2));
+  log('All cookies:', JSON.stringify(req.cookies, null, 2));
   
   const token = req.cookies.token;
   
-  console.log('Token from cookies:', token ? 'Found' : 'Not found');
+  log('Token from cookies:', token ? 'Found' : 'Not found');
   
   if (jwtBlacklist.has(token)) {
     return res.status(401).json({ msg: 'Token is blacklisted' });
@@ -24,7 +30,7 @@ module.exports = (req, res, next) => {
 
   try {
     const decoded = jwt.verify(token, JWT_SECRET);
-    console.log('Token verified successfully:', decoded.user.id);
+    log('Token verified successfully:', decoded.user.id);
     req.user = decoded.user;
     // isActiveチェック
     const User = require('../models/User');


### PR DESCRIPTION
## Summary
- avoid logging auth details in production by wrapping logs with a check

## Testing
- `npm test` *(fails: Missing script)*