### PR TITLE
Fix cookie settings for dev

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -43,10 +43,10 @@ router.post('/register', async (req, res) => {
         
         res.cookie('token', token, {
           httpOnly: true,
-          sameSite: 'none',
+          sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
           maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
           path: '/',
-          secure: true
+          secure: process.env.NODE_ENV === 'production'
         });
         
         res.header('Access-Control-Allow-Credentials', 'true');
@@ -100,10 +100,10 @@ router.post('/login', async (req, res) => {
         
         res.cookie('token', token, {
           httpOnly: true,
-          sameSite: 'none',
+          sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
           maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
           path: '/',
-          secure: true
+          secure: process.env.NODE_ENV === 'production'
         });
         
         res.header('Access-Control-Allow-Credentials', 'true');


### PR DESCRIPTION
## Summary
- only use secure cookie with sameSite none in production
- default to sameSite lax for development so auth works

## Testing
- `npm run lint` *(fails: next not found)*
