### PR TITLE
fix: load characters after auth

### DIFF
--- a/frontend/app/[locale]/setup/page.js
+++ b/frontend/app/[locale]/setup/page.js
@@ -57,6 +57,13 @@ export default function Setup({ params }) {
   }, [user, loading, router, locale]);
 
   useEffect(() => {
+    if (loading) return; // wait for auth state
+
+    if (!user) {
+      router.push(`/${locale}/login`);
+      return;
+    }
+
     const fetchCharacters = async () => {
       try {
         const res = await api.get('/characters');
@@ -68,7 +75,7 @@ export default function Setup({ params }) {
       }
     };
     fetchCharacters();
-  }, []);
+  }, [loading, user, router, locale]);
 
   useEffect(() => {
     if (user?.name) {


### PR DESCRIPTION
## Summary
- fetch characters only after user state is resolved
- redirect to login if auth is missing

## Technical Details
- update setup page to wait for `useAuth` state before calling API
- ensures credential cookie is included so `/characters` returns data
