### PR TITLE
fix: disable cache for characters API

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -5,6 +5,7 @@ const cookieParser = require('cookie-parser');
 require('dotenv').config();
 
 const app = express();
+app.disable('etag'); // disable ETag headers to avoid 304 responses on API requests
 app.use(cors({
   origin: 'http://localhost:3000',
   credentials: true,

--- a/backend/routes/characters.js
+++ b/backend/routes/characters.js
@@ -6,6 +6,7 @@ const Character = require('../models/Character');
 router.get('/', auth, async (req, res) => {
   try {
     const characters = await Character.find({ isActive: true }).select('-adminPrompt');
+    res.set('Cache-Control', 'no-store');
     res.json(characters);
   } catch (err) {
     console.error(err.message);

--- a/frontend/app/[locale]/setup/page.js
+++ b/frontend/app/[locale]/setup/page.js
@@ -57,6 +57,13 @@ export default function Setup({ params }) {
   }, [user, loading, router, locale]);
 
   useEffect(() => {
+    if (loading) return; // wait for auth state
+
+    if (!user) {
+      router.push(`/${locale}/login`);
+      return;
+    }
+
     const fetchCharacters = async () => {
       try {
         const res = await api.get('/characters');
@@ -68,7 +75,7 @@ export default function Setup({ params }) {
       }
     };
     fetchCharacters();
-  }, []);
+  }, [loading, user, router, locale]);
 
   useEffect(() => {
     if (user?.name) {


### PR DESCRIPTION
## 概要
- API の ETag を無効化し、キャラクター一覧取得時に 304 が返らないように変更
- `/characters` エンドポイントで `Cache-Control: no-store` を設定

## 技術的背景
- Express の既定では ETag が有効で、同一リクエストに対して `304 Not Modified` が返ることがある
- Axios は `304` をエラーとして扱うため、フロント側でキャラクター取得に失敗していた可能性がある
- サーバー全体で ETag を無効化し、キャッシュを行わないようにすることで常に `200 OK` を返すよう対応