### PR TITLE
fix: configurable API base URL

### DIFF
--- a/dev-guidelines.md
+++ b/dev-guidelines.md
@@ -45,6 +45,7 @@ ai-character-service/
    - `MONGO_URI`
    - `JWT_SECRET`
    - `OPENAI_API_KEY`
+   - `NEXT_PUBLIC_API_URL` （フロントエンド用、デフォルトは `http://localhost:5000/api`）
 
 3. 開発サーバーの起動：
    - バックエンド: `cd backend && npm run dev`

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=http://localhost:5000/api

--- a/frontend/app/utils/api.js
+++ b/frontend/app/utils/api.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
-const API_URL = 'http://localhost:5000/api';
+// 環境変数から API エンドポイントを取得。存在しない場合はローカル開発用 URL を利用
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5000/api';
 
 const api = axios.create({
   baseURL: API_URL,


### PR DESCRIPTION
## 概要
- 管理画面からのAPI呼び出し先を環境変数で切り替えられるよう修正
- フロントエンド用の`.env.example`を追加
- 開発ガイドラインに `NEXT_PUBLIC_API_URL` の設定項目を追記

## 技術的背景
`frontend/app/utils/api.js` で API エンドポイントが `http://localhost:5000/api` に固定されていたため、ローカル以外の環境ではネットワークエラーが発生していました。環境変数 `NEXT_PUBLIC_API_URL` を参照するよう変更し、デフォルト値として従来のURLを維持します。併せてサンプル設定ファイルとドキュメントを更新し、利用者が任意のバックエンドURLを指定できるようにしました。