### PR TITLE
fix: allow admin cookie outside localhost

### DIFF
--- a/backend/routes/admin/auth.js
+++ b/backend/routes/admin/auth.js
@@ -35,12 +35,12 @@ router.post('/login', async (req, res) => {
       (err, token) => {
         if (err) throw err;
         
+        // cookie の属性は環境によって切り替える
         res.cookie('adminToken', token, {
           httpOnly: true,
-          sameSite: 'lax',
-          maxAge: 24 * 60 * 60 * 1000, // 1日
-          domain: 'localhost',
-          secure: false
+          sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
+          secure: process.env.NODE_ENV === 'production',
+          maxAge: 24 * 60 * 60 * 1000 // 1日
         });
         
         res.json({ success: true });

--- a/dev-guidelines.md
+++ b/dev-guidelines.md
@@ -45,6 +45,7 @@ ai-character-service/
    - `MONGO_URI`
    - `JWT_SECRET`
    - `OPENAI_API_KEY`
+   - `NEXT_PUBLIC_API_URL` （フロントエンド用、デフォルトは `http://localhost:5000/api`）
 
 3. 開発サーバーの起動：
    - バックエンド: `cd backend && npm run dev`

--- a/frontend/app/utils/api.js
+++ b/frontend/app/utils/api.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
-const API_URL = 'http://localhost:5000/api';
+// 環境変数から API エンドポイントを取得。存在しない場合はローカル開発用 URL を利用
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5000/api';
 
 const api = axios.create({
   baseURL: API_URL,


### PR DESCRIPTION
## 概要
- `/admin/login` で設定するCookieのdomain固定を廃止
- `sameSite` と `secure` を `NODE_ENV` から自動設定

## 技術的背景
`backend/routes/admin/auth.js` ではCookieの`domain`が`localhost`に固定されており、本番環境では認証情報が保存されない問題がありました。環境変数に応じて`sameSite`/`secure`を切り替え、ドメイン指定を削除することで、どの環境でも正常に認証Cookieを送受信できるようにしました。
