### PR TITLE
fix: local admin login

### DIFF
--- a/frontend/app/utils/api.js
+++ b/frontend/app/utils/api.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
-// 環境変数から API エンドポイントを取得。存在しない場合はローカル開発用 URL を利用
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5000/api';
+// 環境変数から API エンドポイントを取得。存在しない場合はフロントエンドと同じドメインの `/api` を利用
+const API_URL = process.env.NEXT_PUBLIC_API_URL || '/api';
 
 const api = axios.create({
   baseURL: API_URL,

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -6,7 +6,15 @@ const nextConfig = {
   images: {
     domains: ['localhost'],
   },
-  serverExternalPackages: ['mongoose']
+  serverExternalPackages: ['mongoose'],
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: 'http://localhost:5000/api/:path*'
+      }
+    ];
+  }
 };
 
 module.exports = withNextIntl(nextConfig);


### PR DESCRIPTION
## 概要
- 開発環境で管理者ログインできない問題を修正

## 技術的背景
- ポート3000(frontend)と5000(backend)でドメインが分かれており、Cookie が cross-site 扱いになり送信されていなかった
- `next.config.js` にリライトルールを追加し、`/api` へのリクエストをバックエンドへ転送
- `api.js` のデフォルト `baseURL` を `/api` とすることで同一オリジンを維持
