### PR TITLE
fix: prevent dashboard error with no character

### DIFF
--- a/frontend/app/[locale]/dashboard/dashboard.module.css
+++ b/frontend/app/[locale]/dashboard/dashboard.module.css
@@ -127,4 +127,11 @@
   min-height: 60vh;
   font-size: 1.2rem;
   color: #3a466e;
-} 
+}
+
+.dashboardNoCharacter {
+  font-size: 1.2rem;
+  color: #3a466e;
+  margin-bottom: 16px;
+  text-align: center;
+}

--- a/frontend/app/[locale]/dashboard/page.js
+++ b/frontend/app/[locale]/dashboard/page.js
@@ -18,6 +18,7 @@ export default function Dashboard({ params }) {
   const urlParams = useParams();
   const locale = urlParams.locale || 'ja';
   const t = useTranslations('dashboard');
+  const tMenu = useTranslations('menu');
   
   const handleStartChat = async () => {
     try {
@@ -61,6 +62,25 @@ export default function Dashboard({ params }) {
   
   if (loading || !user) {
     return <GlobalLoading text={t('loading', '読み込み中...')} />;
+  }
+
+  if (!user.selectedCharacter) {
+    return (
+      <div className={styles.dashboardRoot}>
+        <Card className={styles.dashboardCard}>
+          <p className={styles.dashboardNoCharacter}>{t('no_character_selected', '選択中のキャラクターがありません')}</p>
+          <div className={styles.dashboardButtonWrapper}>
+            <button
+              type="button"
+              onClick={handleChangeCharacter}
+              className="button button--primary button--lg"
+            >
+              {tMenu('setup', 'キャラ設定')}
+            </button>
+          </div>
+        </Card>
+      </div>
+    );
   }
   
   const generatePersonalityTags = () => {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -120,7 +120,8 @@
     "no_info": "No information",
     "loading": "Loading...",
     "purchase_character": "Purchase",
-    "price": "Price"
+    "price": "Price",
+    "no_character_selected": "No character selected"
   },
   "chat": {
     "loading": "Loading...",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -130,7 +130,8 @@
     "no_info": "情報なし",
     "loading": "読み込み中...",
     "purchase_character": "購入する",
-    "price": "価格"
+    "price": "価格",
+    "no_character_selected": "選択中のキャラクターがありません"
   },
   "chat": {
     "loading": "読み込み中...",


### PR DESCRIPTION
## 概要
- 選択中のキャラが存在しない場合にダッシュボードでエラーとなっていた不具合を修正
- キャラ未選択時は設定画面へ誘導するUIを追加
- 追加UI用のスタイルと翻訳キーを新規追加

## 技術的背景
ダッシュボードでは `user.selectedCharacter` が `null` の場合でも
`characterType` を参照しており、`TypeError` が発生していました。
未選択時は選択画面へ促す処理を挿入し、翻訳・スタイルも更新しました。