### PR TITLE
fix auth 401 doc

### DIFF
--- a/dev-guidelines.md
+++ b/dev-guidelines.md
@@ -45,7 +45,10 @@ ai-character-service/
    - `MONGO_URI`
    - `JWT_SECRET`
    - `OPENAI_API_KEY`
-   - `NEXT_PUBLIC_API_URL` （フロントエンド用、デフォルトは `http://localhost:5000/api`）
+   - `NEXT_PUBLIC_API_URL`
+     - フロントエンドが API を呼び出す際のベースURL。
+     - 開発環境では `/api` を指定し、Next.js のリライトルートを利用することで
+       Cookie のドメイン不一致による 401 エラーを防ぎます。
 
    - サンプル設定ファイル: `backend/.env.example` と `frontend/.env.example`
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,3 @@
-NEXT_PUBLIC_API_URL=http://localhost:5000/api
+# Base URL for API requests. Use '/api' in development
+# so cookies are issued for the same domain.
+NEXT_PUBLIC_API_URL=/api

--- a/frontend/app/[locale]/dashboard/dashboard.module.css
+++ b/frontend/app/[locale]/dashboard/dashboard.module.css
@@ -127,4 +127,11 @@
   min-height: 60vh;
   font-size: 1.2rem;
   color: #3a466e;
-} 
+}
+
+.dashboardNoCharacter {
+  font-size: 1.2rem;
+  color: #3a466e;
+  margin-bottom: 16px;
+  text-align: center;
+}

--- a/frontend/app/[locale]/dashboard/page.js
+++ b/frontend/app/[locale]/dashboard/page.js
@@ -18,6 +18,7 @@ export default function Dashboard({ params }) {
   const urlParams = useParams();
   const locale = urlParams.locale || 'ja';
   const t = useTranslations('dashboard');
+  const tMenu = useTranslations('menu');
   
   const handleStartChat = async () => {
     try {
@@ -61,6 +62,25 @@ export default function Dashboard({ params }) {
   
   if (loading || !user) {
     return <GlobalLoading text={t('loading', '読み込み中...')} />;
+  }
+
+  if (!user.selectedCharacter) {
+    return (
+      <div className={styles.dashboardRoot}>
+        <Card className={styles.dashboardCard}>
+          <p className={styles.dashboardNoCharacter}>{t('no_character_selected', '選択中のキャラクターがありません')}</p>
+          <div className={styles.dashboardButtonWrapper}>
+            <button
+              type="button"
+              onClick={handleChangeCharacter}
+              className="button button--primary button--lg"
+            >
+              {tMenu('setup', 'キャラ設定')}
+            </button>
+          </div>
+        </Card>
+      </div>
+    );
   }
   
   const generatePersonalityTags = () => {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -120,7 +120,8 @@
     "no_info": "No information",
     "loading": "Loading...",
     "purchase_character": "Purchase",
-    "price": "Price"
+    "price": "Price",
+    "no_character_selected": "No character selected"
   },
   "chat": {
     "loading": "Loading...",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -130,7 +130,8 @@
     "no_info": "情報なし",
     "loading": "読み込み中...",
     "purchase_character": "購入する",
-    "price": "価格"
+    "price": "価格",
+    "no_character_selected": "選択中のキャラクターがありません"
   },
   "chat": {
     "loading": "読み込み中...",


### PR DESCRIPTION
## Summary
- update dev guidelines about NEXT_PUBLIC_API_URL
- default frontend env example to `/api` to avoid cookie issues

## Technical Background
The frontend's axios client depends on `NEXT_PUBLIC_API_URL` for API calls. When this value is set to `http://localhost:5000/api`, the backend issues the auth token for a different domain, causing the browser to omit the cookie on subsequent requests. Using `/api` ensures the cookie domain matches the Next.js dev server and prevents 401 errors after login.

## Testing
- `npm run lint`