### PR TITLE
fix: localization cleanup

### DIFF
--- a/frontend/app/[locale]/login/page.js
+++ b/frontend/app/[locale]/login/page.js
@@ -116,7 +116,7 @@ export default function Login({ params }) {
       {isMobile ? (
         <img
           src="/images/background-mobile.jpg"
-          alt="Background"
+          alt="背景"
           className={styles['background-image']}
         />
       ) : (
@@ -130,7 +130,7 @@ export default function Login({ params }) {
             className={`${styles['background-video']} ${activeVideo === 1 ? styles.active : ''}`}
           >
             <source src={videoFiles[currentVideoIndex]} type="video/mp4" />
-            Your browser does not support the video tag.
+            お使いのブラウザはvideoタグをサポートしていません。
           </video>
           <video
             ref={videoRef2}
@@ -141,7 +141,7 @@ export default function Login({ params }) {
             className={`${styles['background-video']} ${activeVideo === 2 ? styles.active : ''}`}
           >
             <source src={videoFiles[(currentVideoIndex + 1) % videoFiles.length]} type="video/mp4" />
-            Your browser does not support the video tag.
+            お使いのブラウザはvideoタグをサポートしていません。
           </video>
         </>
       )}
@@ -153,9 +153,9 @@ export default function Login({ params }) {
           {serverError && (
             <div className={styles['error-message']}>
               {serverError === 'Invalid credentials'
-                ? t('auth.auth.invalid_credentials')
+                ? t('invalid_credentials')
                 : serverError === 'Login failed'
-                  ? t('auth.auth.login_failed')
+                  ? t('login_failed')
                   : serverError}
             </div>
           )}
@@ -171,7 +171,7 @@ export default function Login({ params }) {
               />
               {errors.email && (
                 <p className={styles['error-message']}>
-                  {errors.email.message === 'Invalid email address' ? t('auth.validation.invalid_email') : errors.email.message}
+                  {errors.email.message === 'Invalid email address' ? t('validation.invalid_email') : errors.email.message}
                 </p>
               )}
             </div>
@@ -186,7 +186,7 @@ export default function Login({ params }) {
               />
               {errors.password && (
                 <p className={styles['error-message']}>
-                  {errors.password.message === 'Password is required' ? t('auth.validation.password_required') : errors.password.message}
+                  {errors.password.message === 'Password is required' ? t('validation.password_required') : errors.password.message}
                 </p>
               )}
             </div>

--- a/frontend/app/[locale]/page.js
+++ b/frontend/app/[locale]/page.js
@@ -279,7 +279,7 @@ export default function Home({ params }) {
       {isMobile ? (
         <img
           src="/images/background-mobile.jpg"
-          alt="Background"
+          alt="背景"
           className={styles['background-image']}
         />
       ) : (
@@ -293,7 +293,7 @@ export default function Home({ params }) {
             className={`${styles['background-video']} ${activeVideo === 1 ? styles.active : ''}`}
           >
             <source src={videoFiles[currentVideoIndex]} type="video/mp4" />
-            Your browser does not support the video tag.
+            お使いのブラウザはvideoタグをサポートしていません。
           </video>
           <video
             ref={videoRef2}
@@ -304,7 +304,7 @@ export default function Home({ params }) {
             className={`${styles['background-video']} ${activeVideo === 2 ? styles.active : ''}`}
           >
             <source src={videoFiles[(currentVideoIndex + 1) % videoFiles.length]} type="video/mp4" />
-            Your browser does not support the video tag.
+            お使いのブラウザはvideoタグをサポートしていません。
           </video>
         </>
       )}
@@ -362,7 +362,7 @@ export default function Home({ params }) {
                 {/* Heart SVG (img) */}
                 <img
                   src="/images/heart.svg"
-                  alt="heart"
+                  alt="ハート"
                   className={`${styles['heart-svg']}${arrowHover ? ' ' + styles['heart-show'] : ''}`}
                 />
               </span>

--- a/frontend/app/[locale]/register/page.js
+++ b/frontend/app/[locale]/register/page.js
@@ -117,7 +117,7 @@ export default function Register({ params }) {
       {isMobile ? (
         <img
           src="/images/background-mobile.jpg"
-          alt="Background"
+          alt="背景"
           className={styles['background-image']}
         />
       ) : (
@@ -131,7 +131,7 @@ export default function Register({ params }) {
             className={`${styles['background-video']} ${activeVideo === 1 ? styles.active : ''}`}
           >
             <source src={videoFiles[currentVideoIndex]} type="video/mp4" />
-            Your browser does not support the video tag.
+            お使いのブラウザはvideoタグをサポートしていません。
           </video>
           <video
             ref={videoRef2}
@@ -142,7 +142,7 @@ export default function Register({ params }) {
             className={`${styles['background-video']} ${activeVideo === 2 ? styles.active : ''}`}
           >
             <source src={videoFiles[(currentVideoIndex + 1) % videoFiles.length]} type="video/mp4" />
-            Your browser does not support the video tag.
+            お使いのブラウザはvideoタグをサポートしていません。
           </video>
         </>
       )}


### PR DESCRIPTION
## Summary
- show login failures in Japanese
- localize validation errors
- update alt text and video tag messages for Japanese pages

## Technical background
- fixed wrong translation keys so `next-intl` finds Japanese strings
- replaced English fallback text with Japanese equivalents