### PR TITLE
fix: image resize and i18n redirect loop

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -21,6 +21,7 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.14.3",
     "multer": "^1.4.5-lts.2",
+    "sharp": "^0.34.1",
     "openai": "^4.100.0"
   },
   "devDependencies": {

--- a/backend/routes/admin/characters.js
+++ b/backend/routes/admin/characters.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router();
 const adminAuth = require('../../middleware/adminAuth');
 const Character = require('../../models/Character');
-const { uploadImage, uploadVoice } = require('../../utils/fileUpload');
+const { uploadImage, uploadVoice, resizeImage } = require('../../utils/fileUpload');
 
 router.get('/', adminAuth, async (req, res) => {
   try {
@@ -163,7 +163,7 @@ router.delete('/:id', adminAuth, async (req, res) => {
   }
 });
 
-router.post('/upload/image', adminAuth, uploadImage.single('image'), (req, res) => {
+router.post('/upload/image', adminAuth, uploadImage.single('image'), resizeImage(), (req, res) => {
   try {
     if (!req.file) {
       return res.status(400).json({ msg: 'アップロードするファイルが選択されていません' });

--- a/backend/utils/fileUpload.js
+++ b/backend/utils/fileUpload.js
@@ -1,6 +1,7 @@
 const multer = require('multer');
 const path = require('path');
 const fs = require('fs');
+const sharp = require('sharp');
 
 const createUploadDir = (dir) => {
   const uploadDir = path.join(__dirname, '../../frontend/public', dir);
@@ -62,7 +63,23 @@ const uploadVoice = multer({
   limits: { fileSize: 10 * 1024 * 1024 } // 10MB制限
 });
 
+const resizeImage = (width = 512, height = 512) => async (req, res, next) => {
+  try {
+    if (!req.file) return next();
+
+    const tmpPath = req.file.path + '.tmp';
+    await sharp(req.file.path)
+      .resize(width, height, { fit: 'inside' })
+      .toFile(tmpPath);
+    await fs.promises.rename(tmpPath, req.file.path);
+    next();
+  } catch (err) {
+    next(err);
+  }
+};
+
 module.exports = {
   uploadImage,
-  uploadVoice
+  uploadVoice,
+  resizeImage
 };

--- a/frontend/app/utils/api.js
+++ b/frontend/app/utils/api.js
@@ -18,8 +18,13 @@ api.interceptors.response.use(
         if (current !== '/admin/login') {
           window.location.href = '/admin/login';
         }
-      } else if (current !== '/login') {
-        window.location.href = '/login';
+      } else {
+        const localeMatch = current.match(/^\/(ja|en)(\/|$)/);
+        const locale = localeMatch ? localeMatch[1] : null;
+        const loginPath = locale ? `/${locale}/login` : '/login';
+        if (current !== loginPath) {
+          window.location.href = loginPath;
+        }
       }
     }
     console.error('API Error:', error.response?.status, error.response?.data);


### PR DESCRIPTION
## Summary
- resize character images on upload using sharp
- update admin upload route to resize images
- adjust API interceptor to respect locale-specific login paths
- add sharp dependency for backend

## Technical Details
- added `resizeImage` helper leveraging `sharp`
- symlinked shared `sharp` package from frontend to avoid network install
- interceptor now detects `/ja` or `/en` path prefixes to build correct login route
