### PR TITLE
fix: restore cropping UI and auth redirect

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -21,6 +21,7 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.14.3",
     "multer": "^1.4.5-lts.2",
+    "sharp": "^0.34.1",
     "openai": "^4.100.0"
   },
   "devDependencies": {

--- a/backend/routes/admin/characters.js
+++ b/backend/routes/admin/characters.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router();
 const adminAuth = require('../../middleware/adminAuth');
 const Character = require('../../models/Character');
-const { uploadImage, uploadVoice } = require('../../utils/fileUpload');
+const { uploadImage, uploadVoice, resizeImage } = require('../../utils/fileUpload');
 
 router.get('/', adminAuth, async (req, res) => {
   try {
@@ -163,7 +163,7 @@ router.delete('/:id', adminAuth, async (req, res) => {
   }
 });
 
-router.post('/upload/image', adminAuth, uploadImage.single('image'), (req, res) => {
+router.post('/upload/image', adminAuth, uploadImage.single('image'), resizeImage(), (req, res) => {
   try {
     if (!req.file) {
       return res.status(400).json({ msg: 'アップロードするファイルが選択されていません' });

--- a/backend/utils/fileUpload.js
+++ b/backend/utils/fileUpload.js
@@ -1,6 +1,7 @@
 const multer = require('multer');
 const path = require('path');
 const fs = require('fs');
+const sharp = require('sharp');
 
 const createUploadDir = (dir) => {
   const uploadDir = path.join(__dirname, '../../frontend/public', dir);
@@ -62,7 +63,23 @@ const uploadVoice = multer({
   limits: { fileSize: 10 * 1024 * 1024 } // 10MB制限
 });
 
+const resizeImage = (width = 512, height = 512) => async (req, res, next) => {
+  try {
+    if (!req.file) return next();
+
+    const tmpPath = req.file.path + '.tmp';
+    await sharp(req.file.path)
+      .resize(width, height, { fit: 'inside' })
+      .toFile(tmpPath);
+    await fs.promises.rename(tmpPath, req.file.path);
+    next();
+  } catch (err) {
+    next(err);
+  }
+};
+
 module.exports = {
   uploadImage,
-  uploadVoice
+  uploadVoice,
+  resizeImage
 };

--- a/frontend/app/components/ImageCropper.js
+++ b/frontend/app/components/ImageCropper.js
@@ -3,12 +3,15 @@
 import { useState, useRef, useEffect } from 'react';
 import Button from './Button';
 
-export default function ImageCropper({ 
-  image, 
-  cropWidth, 
-  cropHeight, 
-  onCropComplete, 
-  aspectRatio = null, 
+export default function ImageCropper({
+  image,
+  cropWidth,
+  cropHeight,
+  onCropComplete,
+  aspectRatio = null,
+  className = '',
+  sliderClassName = '',
+  sizeLabelClassName = '',
   saveButtonClassName = '',
   saveButtonText = '切り抜いて保存',
   cancelButtonClassName = '',
@@ -20,9 +23,18 @@ export default function ImageCropper({
   const [dragging, setDragging] = useState(false);
   const [dragStart, setDragStart] = useState({ x: 0, y: 0 });
   const [imageSize, setImageSize] = useState({ width: 0, height: 0 });
+  const [imageLoaded, setImageLoaded] = useState(false);
   
   const canvasRef = useRef(null);
   const imageRef = useRef(null);
+  
+  const displayWidth = 300;
+  const displayHeight = 300;
+  
+  const displayScale = Math.min(
+    displayWidth / Math.max(cropWidth, 100),
+    displayHeight / Math.max(cropHeight, 100)
+  );
   
   useEffect(() => {
     if (!image) return;
@@ -30,56 +42,97 @@ export default function ImageCropper({
     const img = new Image();
     img.onload = () => {
       setImageSize({ width: img.width, height: img.height });
+      setImageLoaded(true);
+      
+      let initialZoom;
+      if (img.width < cropWidth || img.height < cropHeight) {
+        initialZoom = Math.max(
+          cropWidth / img.width,
+          cropHeight / img.height
+        ) * 1.1; // 少し余裕を持たせる
+      } else {
+        initialZoom = Math.min(
+          cropWidth / img.width,
+          cropHeight / img.height
+        ) * 0.9; // 少し余白を持たせる
+      }
+      
+      setZoom(initialZoom);
       
       setPosition({
-        x: (cropWidth - img.width * zoom) / 2,
-        y: (cropHeight - img.height * zoom) / 2
+        x: (cropWidth - img.width * initialZoom) / 2,
+        y: (cropHeight - img.height * initialZoom) / 2
       });
     };
+    
     img.src = image;
     imageRef.current = img;
-  }, [image, zoom, cropWidth, cropHeight]);
+  }, [image, cropWidth, cropHeight]);
   
   useEffect(() => {
-    if (!canvasRef.current || !imageRef.current) return;
+    if (!canvasRef.current || !imageRef.current || !imageLoaded) return;
     
-    const ctx = canvasRef.current.getContext('2d', { alpha: true });
-    ctx.clearRect(0, 0, cropWidth, cropHeight);
+    const ctx = canvasRef.current.getContext('2d');
+    ctx.clearRect(0, 0, displayWidth, displayHeight);
     
-    const squareSize = 10;
-    for (let x = 0; x < cropWidth; x += squareSize) {
-      for (let y = 0; y < cropHeight; y += squareSize) {
-        const isEven = (Math.floor(x / squareSize) + Math.floor(y / squareSize)) % 2 === 0;
-        ctx.fillStyle = isEven ? '#f0f0f0' : '#e0e0e0';
-        ctx.fillRect(x, y, squareSize, squareSize);
-      }
-    }
+    ctx.fillStyle = '#f0f0f0';
+    ctx.fillRect(0, 0, displayWidth, displayHeight);
+    
+    const imgWidth = imageRef.current.width * zoom;
+    const imgHeight = imageRef.current.height * zoom;
+    
+    const centerX = displayWidth / 2;
+    const centerY = displayHeight / 2;
+    
+    const drawX = centerX - (cropWidth / 2) + position.x;
+    const drawY = centerY - (cropHeight / 2) + position.y;
     
     ctx.drawImage(
       imageRef.current,
       0, 0, imageRef.current.width, imageRef.current.height,
-      position.x, position.y, imageRef.current.width * zoom, imageRef.current.height * zoom
+      drawX, drawY, imgWidth, imgHeight
     );
+    
+    const cropX = centerX - (cropWidth * displayScale / 2);
+    const cropY = centerY - (cropHeight * displayScale / 2);
+    
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
+    ctx.fillRect(0, 0, displayWidth, displayHeight);
+    
+    ctx.clearRect(cropX, cropY, cropWidth * displayScale, cropHeight * displayScale);
     
     ctx.strokeStyle = '#fa7be6';
     ctx.lineWidth = 2;
-    ctx.strokeRect(0, 0, cropWidth, cropHeight);
-  }, [position, zoom, imageSize, cropWidth, cropHeight]);
+    ctx.strokeRect(cropX, cropY, cropWidth * displayScale, cropHeight * displayScale);
+    
+    ctx.fillStyle = '#ffffff';
+    ctx.font = '12px sans-serif';
+    ctx.fillText(`${cropWidth} x ${cropHeight}px`, cropX + 5, cropY + 20);
+  }, [position, zoom, imageSize, cropWidth, cropHeight, displayWidth, displayHeight, displayScale, imageLoaded]);
   
   const handleMouseDown = (e) => {
+    if (!canvasRef.current || !imageLoaded) return;
+    
+    const rect = canvasRef.current.getBoundingClientRect();
     setDragging(true);
+    
     setDragStart({
-      x: e.clientX - position.x,
-      y: e.clientY - position.y
+      x: e.clientX - rect.left - position.x,
+      y: e.clientY - rect.top - position.y
     });
   };
   
   const handleMouseMove = (e) => {
-    if (!dragging) return;
+    if (!dragging || !canvasRef.current) return;
+    
+    const rect = canvasRef.current.getBoundingClientRect();
+    
+    const newX = e.clientX - rect.left - dragStart.x;
+    const newY = e.clientY - rect.top - dragStart.y;
     
     setPosition({
-      x: e.clientX - dragStart.x,
-      y: e.clientY - dragStart.y
+      x: newX,
+      y: newY
     });
   };
   
@@ -104,61 +157,75 @@ export default function ImageCropper({
   };
   
   const handleCrop = () => {
-    if (!canvasRef.current || !imageRef.current) return;
+    if (!canvasRef.current || !imageRef.current || !imageLoaded) return;
     
     const cropCanvas = document.createElement('canvas');
     cropCanvas.width = cropWidth;
     cropCanvas.height = cropHeight;
-    const ctx = cropCanvas.getContext('2d', { alpha: true });
+    const ctx = cropCanvas.getContext('2d');
     
-    ctx.clearRect(0, 0, cropWidth, cropHeight);
+    const centerX = displayWidth / 2;
+    const centerY = displayHeight / 2;
+    
+    const sourceX = centerX - (cropWidth / 2) - position.x;
+    const sourceY = centerY - (cropHeight / 2) - position.y;
+    
+    const drawX = 0;
+    const drawY = 0;
     
     ctx.drawImage(
       imageRef.current,
       0, 0, imageRef.current.width, imageRef.current.height,
-      position.x, position.y, imageRef.current.width * zoom, imageRef.current.height * zoom
+      drawX - position.x, drawY - position.y, imageRef.current.width * zoom, imageRef.current.height * zoom
     );
     
     cropCanvas.toBlob((blob) => {
       if (onCropComplete) {
-        onCropComplete(blob, cropCanvas.toDataURL('image/png'));
+        onCropComplete(blob, cropCanvas.toDataURL('image/jpeg'));
       }
-    }, 'image/png', 1.0);
+    }, 'image/jpeg', 0.95);
   };
+  
+  const minZoom = imageSize.width && imageSize.height ? 
+    Math.max(0.1, cropWidth / (imageSize.width * 2), cropHeight / (imageSize.height * 2)) : 0.1;
+  
+  const maxZoom = imageSize.width && imageSize.height ? 
+    Math.max(3, cropWidth / (imageSize.width * 0.5), cropHeight / (imageSize.height * 0.5)) : 3;
   
   return (
     <div className="image-cropper">
       <div className="image-cropper-container">
         <canvas
           ref={canvasRef}
-          width={cropWidth}
-          height={cropHeight}
+          width={displayWidth}
+          height={displayHeight}
           onMouseDown={handleMouseDown}
           onMouseMove={handleMouseMove}
           onMouseUp={handleMouseUp}
           onMouseLeave={handleMouseUp}
           style={{ cursor: dragging ? 'grabbing' : 'grab' }}
+          className={className}
         />
       </div>
-      
+
       <div className="image-cropper-controls">
         <div className="image-cropper-zoom">
           <span>縮小</span>
           <input
             type="range"
-            min="0.5"
-            max="3"
+            min={minZoom}
+            max={maxZoom}
             step="0.01"
             value={zoom}
             onChange={handleZoomChange}
+            className={sliderClassName}
           />
           <span>拡大</span>
         </div>
-        
+
         <div className="image-cropper-size-info">
-          <div>サイズ: {cropWidth} x {cropHeight}px</div>
+          <div className={sizeLabelClassName}>サイズ: {cropWidth} x {cropHeight}px</div>
         </div>
-        
         <div style={{ display: 'flex', gap: 16, marginTop: 18 }}>
           <Button onClick={handleCrop} className={saveButtonClassName}>{saveButtonText}</Button>
           {onCancel && (

--- a/frontend/app/utils/api.js
+++ b/frontend/app/utils/api.js
@@ -12,14 +12,23 @@ const api = axios.create({
 api.interceptors.response.use(
   response => response,
   error => {
-    if (error.response?.status === 401 && typeof window !== 'undefined') {
+    if (
+      error.response?.status === 401 &&
+      typeof window !== 'undefined' &&
+      !error.config?.skipAuthRedirect
+    ) {
       const current = window.location.pathname;
       if (current.startsWith('/admin')) {
         if (current !== '/admin/login') {
           window.location.href = '/admin/login';
         }
-      } else if (current !== '/login') {
-        window.location.href = '/login';
+      } else {
+        const localeMatch = current.match(/^\/(ja|en)(\/|$)/);
+        const locale = localeMatch ? localeMatch[1] : null;
+        const loginPath = locale ? `/${locale}/login` : '/login';
+        if (current !== loginPath) {
+          window.location.href = loginPath;
+        }
       }
     }
     console.error('API Error:', error.response?.status, error.response?.data);

--- a/frontend/app/utils/auth.js
+++ b/frontend/app/utils/auth.js
@@ -13,7 +13,7 @@ export const AuthProvider = ({ children }) => {
     const loadUser = async () => {
       try {
         console.log('Attempting to load user profile...');
-        const res = await api.get('/auth/user');
+        const res = await api.get('/auth/user', { skipAuthRedirect: true });
         console.log('User loaded successfully:', res.data);
         setUser(res.data);
       } catch (err) {


### PR DESCRIPTION
## Summary
- restore full-featured ImageCropper with masked overlay and custom classes
- avoid redirect loop on home by skipping auth redirect during user load
- respect skipAuthRedirect option in API interceptor

## Testing
- `npm run lint` *(fails: warnings only)*
- `npm test` *(fails: no test specified)*