### PR TITLE
fix: restore image cropper modal on character create

### DIFF
--- a/frontend/app/admin/characters/new/page.js
+++ b/frontend/app/admin/characters/new/page.js
@@ -89,7 +89,7 @@ export default function CharacterNewPage() {
       return;
     }
     
-    if (file.type.startsWith('image/'))
+    if (file.type.startsWith('image/')) {
       const url = URL.createObjectURL(file);
       setSelectedImage(url);
       setImageType(type);


### PR DESCRIPTION
## 目的
- 管理画面で画像アップロード時にリサイズ・トリミングモーダルが表示されない問題を解消する

## 技術的背景
- `character`新規登録画面の `handleImageUpload` で条件分岐の波括弧が欠けており、モーダル表示処理が正しく実行されていなかった
- `if` ブロックを修正してモーダルが再び開くようにした
