### PR TITLE
fix: restore FileReader image upload

### DIFF
--- a/frontend/app/admin/characters/[id]/edit/page.js
+++ b/frontend/app/admin/characters/[id]/edit/page.js
@@ -145,10 +145,13 @@ export default function EditCharacter({ params }) {
     }
     
     if (file.type.startsWith('image/')) {
-      const url = URL.createObjectURL(file);
-      setSelectedImage(url);
-      setImageType(type);
-      setShowCropper(true);
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        setSelectedImage(e.target.result);
+        setImageType(type);
+        setShowCropper(true);
+      };
+      reader.readAsDataURL(file);
       e.target.value = '';
       return;
     }

--- a/frontend/app/admin/characters/new/page.js
+++ b/frontend/app/admin/characters/new/page.js
@@ -89,11 +89,14 @@ export default function CharacterNewPage() {
       return;
     }
     
-    if (file.type.startsWith('image/'))
-      const url = URL.createObjectURL(file);
-      setSelectedImage(url);
-      setImageType(type);
-      setShowCropper(true);
+    if (file.type.startsWith('image/')) {
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        setSelectedImage(e.target.result);
+        setImageType(type);
+        setShowCropper(true);
+      };
+      reader.readAsDataURL(file);
       e.target.value = '';
       return;
     }


### PR DESCRIPTION
## 目的
- 画像アップロード後にクロッパーモーダルが表示されない問題を解消する

## 技術的背景
- `handleImageUpload` で `URL.createObjectURL` を使用していたが、旧実装では `FileReader` で DataURL を生成していた
- これを元に戻すことで選択画像が正しくモーダルに表示され、リサイズ・トリミングできるようにする