### PR TITLE
fix: separate admin token cookie

### DIFF
--- a/backend/middleware/adminAuth.js
+++ b/backend/middleware/adminAuth.js
@@ -13,7 +13,7 @@ module.exports = (req, res, next) => {
   log('=== Admin Auth Middleware ===');
   log('Request path:', req.path);
   
-  const token = req.cookies.token;
+  const token = req.cookies.adminToken;
   
   log('Admin token from cookies:', token ? 'Found' : 'Not found');
   

--- a/backend/routes/admin/auth.js
+++ b/backend/routes/admin/auth.js
@@ -34,9 +34,9 @@ router.post('/login', async (req, res) => {
       { expiresIn: '1d' },
       (err, token) => {
         if (err) throw err;
-        
+
         // cookie の属性は環境によって切り替える
-        res.cookie('token', token, {
+        res.cookie('adminToken', token, {
           httpOnly: true,
           sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
 
@@ -44,7 +44,7 @@ router.post('/login', async (req, res) => {
           secure: process.env.NODE_ENV === 'production'
 
         });
-        
+
         res.json({ success: true });
       }
     );
@@ -65,7 +65,7 @@ router.get('/user', adminAuth, async (req, res) => {
 });
 
 router.post('/logout', adminAuth, (req, res) => {
-  res.clearCookie('token', {
+  res.clearCookie('adminToken', {
     path: '/',
     sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
     secure: process.env.NODE_ENV === 'production'


### PR DESCRIPTION
## Summary
- separate the admin session cookie from the user session cookie
- let admin middleware read `adminToken`

## Testing
- `npm test` *(fails: Missing script)*
- `cd backend && npm test` *(fails: no test specified)*
- `cd frontend && npm run lint`
