### PR TITLE
feature: update crop handling in edit form

### DIFF
--- a/frontend/app/admin/characters/[id]/edit/page.js
+++ b/frontend/app/admin/characters/[id]/edit/page.js
@@ -59,6 +59,7 @@ export default function EditCharacter({ params }) {
   const [imageType, setImageType] = useState('');
   const [showCropper, setShowCropper] = useState(false);
   const [previewUrl, setPreviewUrl] = useState('');
+  const [croppedImages, setCroppedImages] = useState({});
   const ratioOptions = {
     '1:1': { width: 400, height: 400 },
     '16:9': { width: 480, height: 270 }
@@ -137,6 +138,10 @@ export default function EditCharacter({ params }) {
       fd.append('defaultMessage', JSON.stringify(formData.defaultMessage));
       fd.append('themeColor', formData.themeColor);
       fd.append('isActive', formData.isActive);
+      if (croppedImages.characterSelect) {
+        const file = new File([croppedImages.characterSelect], `upload_${Date.now()}.jpg`, { type: 'image/jpeg' });
+        fd.append('image', file);
+      }
 
       const res = await api.put(`/admin/characters/${id}`, fd, {
         headers: { 'Content-Type': 'multipart/form-data' }
@@ -215,23 +220,11 @@ export default function EditCharacter({ params }) {
   const handleCropComplete = async (blob, dataUrl) => {
     setShowCropper(false);
     setPreviewUrl(dataUrl);
-
-    if (imageType === 'characterSelect') {
-      const file = new File([blob], `upload_${Date.now()}.jpg`, { type: 'image/jpeg' });
-      const fd = new FormData();
-      fd.append('image', file);
-
-      try {
-        const res = await api.put(`/admin/characters/${id}`, fd, {
-          headers: { 'Content-Type': 'multipart/form-data' }
-        });
-
-        setFormData(res.data);
-      } catch (err) {
-        console.error('画像アップロードに失敗:', err);
-        setToast({ show: true, message: '画像のアップロードに失敗しました', type: 'error' });
-      }
-    }
+    setCroppedImages(prev => ({ ...prev, [imageType]: blob }));
+    setFormData(prev => ({
+      ...prev,
+      [`image${imageType.charAt(0).toUpperCase() + imageType.slice(1)}`]: dataUrl
+    }));
   };
   
   const handleVoiceUpload = async (e) => {


### PR DESCRIPTION
## 目的
キャラクター編集画面で画像トリミング後に保存処理へ連携するため、切り抜き画像を `saveCharacter` 相当の処理へ渡すようにしました。

## 技術的背景
これまではトリミング確定時点で即座にアップロードを行っていましたが、フォーム保存時にまとめて送信する仕様へ変更しました。`croppedImages` ステートを復活させ、`handleSubmit` で `FormData` に画像を追加しています。