### PR TITLE
ダッシュボードページに画像スライダーを追加

### DIFF
--- a/frontend/app/[locale]/dashboard/page.js
+++ b/frontend/app/[locale]/dashboard/page.js
@@ -10,6 +10,7 @@ import { useTranslations } from 'next-intl';
 import Card from '../../components/Card';
 import styles from './dashboard.module.css';
 import GlobalLoading from '../../components/GlobalLoading';
+import ImageSlider from '../../components/ImageSlider';
 
 export default function Dashboard({ params }) {
   const { user, loading, element } = useRequireAuth();
@@ -146,6 +147,15 @@ export default function Dashboard({ params }) {
       <Card className={styles.dashboardCard}>
         <div className={styles.dashboardGrid}>
           <div className={styles.dashboardImageWrapper}>
+            <ImageSlider
+              images={[
+                { src: '/images/room_01.jpg', alt: 'ルーム画像1' },
+                { src: '/images/room_02.jpg', alt: 'ルーム画像2' },
+                { src: '/images/room_03.jpg', alt: 'ルーム画像3' },
+                { src: '/images/room_04.jpg', alt: 'ルーム画像4' }
+              ]}
+              interval={4000}
+            />
             {user.selectedCharacter?.imageDashboard ? (
               <img
                 src={user.selectedCharacter.imageDashboard}

--- a/frontend/app/components/ImageSlider.js
+++ b/frontend/app/components/ImageSlider.js
@@ -1,0 +1,104 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import styles from './ImageSlider.module.css';
+
+export default function ImageSlider({ images, interval = 5000 }) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isTransitioning, setIsTransitioning] = useState(false);
+
+  useEffect(() => {
+    if (!images || images.length <= 1) return;
+
+    const timer = setInterval(() => {
+      nextSlide();
+    }, interval);
+
+    return () => clearInterval(timer);
+  }, [currentIndex, images, interval]);
+
+  const nextSlide = () => {
+    if (!images || images.length === 0) return;
+    setIsTransitioning(true);
+    setTimeout(() => {
+      setCurrentIndex((prevIndex) => (prevIndex + 1) % images.length);
+      setIsTransitioning(false);
+    }, 300);
+  };
+
+  const prevSlide = () => {
+    if (!images || images.length === 0) return;
+    setIsTransitioning(true);
+    setTimeout(() => {
+      setCurrentIndex((prevIndex) => 
+        prevIndex === 0 ? images.length - 1 : prevIndex - 1
+      );
+      setIsTransitioning(false);
+    }, 300);
+  };
+
+  const goToSlide = (index) => {
+    setIsTransitioning(true);
+    setTimeout(() => {
+      setCurrentIndex(index);
+      setIsTransitioning(false);
+    }, 300);
+  };
+
+  if (!images || images.length === 0) {
+    return null;
+  }
+
+  if (images.length === 1) {
+    return (
+      <div className={styles.sliderContainer}>
+        <div className={styles.imageWrapper}>
+          <img
+            src={images[0].src}
+            alt={images[0].alt || ''}
+            className={styles.slideImage}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.sliderContainer}>
+      <div className={styles.imageWrapper}>
+        <img
+          src={images[currentIndex].src}
+          alt={images[currentIndex].alt || ''}
+          className={`${styles.slideImage} ${isTransitioning ? styles.transitioning : ''}`}
+        />
+        
+        <button
+          onClick={prevSlide}
+          className={`${styles.navButton} ${styles.prevButton}`}
+          aria-label="前の画像"
+        >
+          &#8249;
+        </button>
+        
+        <button
+          onClick={nextSlide}
+          className={`${styles.navButton} ${styles.nextButton}`}
+          aria-label="次の画像"
+        >
+          &#8250;
+        </button>
+      </div>
+      
+      <div className={styles.dotsContainer}>
+        {images.map((_, index) => (
+          <button
+            key={index}
+            onClick={() => goToSlide(index)}
+            className={`${styles.dot} ${index === currentIndex ? styles.activeDot : ''}`}
+            aria-label={`スライド ${index + 1}`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/components/ImageSlider.module.css
+++ b/frontend/app/components/ImageSlider.module.css
@@ -1,0 +1,81 @@
+.sliderContainer {
+  width: 100%;
+  position: relative;
+  margin-bottom: 24px;
+}
+
+.imageWrapper {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  border-radius: 8px;
+}
+
+.slideImage {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+  display: block;
+  transition: opacity 0.3s ease-in-out;
+}
+
+.slideImage.transitioning {
+  opacity: 0.7;
+}
+
+.navButton {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background-color: rgba(0, 0, 0, 0.5);
+  color: white;
+  border: none;
+  font-size: 24px;
+  padding: 8px 12px;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background-color 0.3s ease;
+  z-index: 2;
+}
+
+.navButton:hover {
+  background-color: rgba(0, 0, 0, 0.7);
+}
+
+.prevButton {
+  left: 10px;
+}
+
+.nextButton {
+  right: 10px;
+}
+
+.dotsContainer {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: none;
+  background-color: #d1d5db;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+  padding: 0;
+}
+
+.dot:hover {
+  background-color: #9ca3af;
+}
+
+.activeDot {
+  background-color: #75C6D1;
+}
+
+.activeDot:hover {
+  background-color: #5db6c1;
+}


### PR DESCRIPTION
## Summary
- ダッシュボードページの左コンテンツ上部に画像スライダーコンポーネントを追加
- room_01.jpg〜room_04.jpgの4枚の画像を自動でスライド表示（4秒間隔）
- ユーザーが手動で操作できるナビゲーション機能も実装

## Test plan
- [ ] ダッシュボードページで画像スライダーが正しく表示されることを確認
- [ ] 自動スライド機能が4秒間隔で動作することを確認
- [ ] 左右のナビゲーションボタンで手動切り替えができることを確認
- [ ] ドットインジケーターで任意のスライドに移動できることを確認
- [ ] トランジション効果がスムーズに動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)