### PR TITLE
イメージスライダーをdashboardCardの上に移動

### DIFF
--- a/frontend/app/[locale]/dashboard/dashboard.module.css
+++ b/frontend/app/[locale]/dashboard/dashboard.module.css
@@ -157,3 +157,9 @@
 .dashboardPrimaryButton:hover {
   background: #5db6c1;
 }
+
+.dashboardRoot > div:first-child {
+  max-width: 900px;
+  margin: 0 auto;
+  margin-bottom: 24px;
+}

--- a/frontend/app/[locale]/dashboard/page.js
+++ b/frontend/app/[locale]/dashboard/page.js
@@ -148,18 +148,18 @@ export default function Dashboard({ params }) {
 
   return (
     <div className={styles.dashboardRoot}>
+      <ImageSlider
+        images={[
+          { src: '/images/room_01.jpg', alt: 'ルーム画像1' },
+          { src: '/images/room_02.jpg', alt: 'ルーム画像2' },
+          { src: '/images/room_03.jpg', alt: 'ルーム画像3' },
+          { src: '/images/room_04.jpg', alt: 'ルーム画像4' }
+        ]}
+        interval={4000}
+      />
       <Card className={styles.dashboardCard}>
         <div className={styles.dashboardGrid}>
           <div className={styles.dashboardImageWrapper}>
-            <ImageSlider
-              images={[
-                { src: '/images/room_01.jpg', alt: 'ルーム画像1' },
-                { src: '/images/room_02.jpg', alt: 'ルーム画像2' },
-                { src: '/images/room_03.jpg', alt: 'ルーム画像3' },
-                { src: '/images/room_04.jpg', alt: 'ルーム画像4' }
-              ]}
-              interval={4000}
-            />
             {user.selectedCharacter?.imageDashboard ? (
               <img
                 src={user.selectedCharacter.imageDashboard}


### PR DESCRIPTION
## Summary
- ダッシュボードページのイメージスライダーをCard要素の外側（上部）に移動
- スライダーの幅を最大900pxに制限し、中央揃えに配置
- カードとの適切な間隔（24px）を確保

## Test plan
- [ ] ダッシュボードページでイメージスライダーがカードの上に表示されることを確認
- [ ] スライダーの幅が900pxを超えないことを確認
- [ ] スライダーが中央に配置されていることを確認
- [ ] カードとの間に適切な余白があることを確認
- [ ] 自動スライド機能が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)