### PR TITLE
モーダルのナビゲーションボタンにarrow.svgアイコンを追加

### DIFF
--- a/frontend/app/components/ImageModal.js
+++ b/frontend/app/components/ImageModal.js
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import Image from 'next/image';
 import styles from './ImageModal.module.css';
 
 export default function ImageModal({ images, initialIndex, onClose }) {
@@ -82,7 +83,13 @@ export default function ImageModal({ images, initialIndex, onClose }) {
                 onClick={prevImage}
                 aria-label="前の画像"
               >
-                &#8249;
+                <Image
+                  src="/icon/arrow.svg"
+                  alt=""
+                  width={24}
+                  height={24}
+                  className={styles.arrowIcon}
+                />
               </button>
               
               <button
@@ -90,7 +97,13 @@ export default function ImageModal({ images, initialIndex, onClose }) {
                 onClick={nextImage}
                 aria-label="次の画像"
               >
-                &#8250;
+                <Image
+                  src="/icon/arrow.svg"
+                  alt=""
+                  width={24}
+                  height={24}
+                  className={styles.arrowIcon}
+                />
               </button>
             </>
           )}

--- a/frontend/app/components/ImageModal.module.css
+++ b/frontend/app/components/ImageModal.module.css
@@ -75,7 +75,6 @@
   background-color: rgba(255, 255, 255, 0.9);
   color: #333;
   border: none;
-  font-size: 36px;
   width: 50px;
   height: 50px;
   border-radius: 50%;
@@ -84,6 +83,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 0;
 }
 
 .navButton:hover {
@@ -155,6 +155,15 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
+}
+
+.arrowIcon {
+  width: 24px;
+  height: 24px;
+}
+
+.prevButton .arrowIcon {
+  transform: rotate(180deg);
 }
 
 /* レスポンシブ対応 */

--- a/frontend/public/icon/arrow.svg
+++ b/frontend/public/icon/arrow.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M9 5L16 12L9 19" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Summary
- ImageModalのナビゲーションボタンにSVGアイコンを追加
- テキスト文字（‹ ›）の代わりに矢印アイコンを使用してUI改善

## Changes
- arrow.svgファイルを新規作成（右向きの矢印アイコン）
- モーダルの左右ナビゲーションボタンにSVGアイコンを適用
- 左ボタンではCSS transformで180度回転させて左向き矢印として使用

## Test plan
- [ ] モーダルを開いて左右のナビゲーションボタンに矢印アイコンが表示されることを確認
- [ ] 右ボタンは右向き、左ボタンは左向きの矢印になっていることを確認
- [ ] ボタンのホバー効果が正常に動作することを確認
- [ ] アイコンのサイズと位置が適切であることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)