### PR TITLE
親密度ハートの色を指定色に変更

### DIFF
--- a/frontend/app/components/AffinityBar.js
+++ b/frontend/app/components/AffinityBar.js
@@ -22,14 +22,10 @@ export default function AffinityBar({ level = 0, streak = 0, description }) {
     
     if (heartIndex < heartsToFill) {
       // 完全に塗りつぶされたハート
-      if (level >= 85) return '#FF1493'; // ピンク（恋人）
-      if (level >= 60) return '#FFD700'; // ゴールド（親友）
-      if (level >= 40) return '#32CD32'; // グリーン（友達）
-      if (level >= 20) return '#87CEEB'; // ライトブルー（知り合い）
-      return '#FF69B4'; // 基本ピンク
+      return 'rgb(248, 144, 182)'; // 指定されたピンク色
     } else if (heartIndex === heartsToFill && partialFill > 0) {
       // 部分的に塗りつぶされたハート
-      return '#FFB6C1'; // 薄いピンク
+      return 'rgb(255, 229, 239)'; // 指定された薄いピンク色
     }
     // 空のハート
     return '#E5E5E5';


### PR DESCRIPTION
## Summary
親密度バーのハートの色を指定された色に変更し、統一感のあるピンク系カラーパレットに調整

## Changes

### 色の変更
- **完全に塗りつぶされたハート**: `rgb(248, 144, 182)` に変更
- **部分的に塗りつぶされたハート**: `rgb(255, 229, 239)` に変更

### 改善点
- 統一感のあるピンク系カラーパレット
- より柔らかく優しい印象のハート表示
- ブランドカラーに沿った色設計

## Before/After

### Before
- 完全塗りつぶし: 複数色（レベル別）
- 部分塗りつぶし: `#FFB6C1`

### After  
- 完全塗りつぶし: `rgb(248, 144, 182)`（統一ピンク）
- 部分塗りつぶし: `rgb(255, 229, 239)`（淡いピンク）

## Test Plan
- [ ] 親密度レベルに関係なく、塗りつぶされたハートが`rgb(248, 144, 182)`で表示される
- [ ] 部分的に塗りつぶされたハート（現在のレベル境界）が`rgb(255, 229, 239)`で表示される
- [ ] 空のハートは従来通り`#E5E5E5`（グレー）で表示される

🤖 Generated with [Claude Code](https://claude.ai/code)