### PR TITLE
ハートアイコンをSVGに変更して色を正しく反映

### DIFF
--- a/frontend/app/components/AffinityBar.js
+++ b/frontend/app/components/AffinityBar.js
@@ -1,7 +1,6 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import Image from 'next/image';
 import styles from './AffinityBar.module.css';
 
 export default function AffinityBar({ level = 0, streak = 0, description }) {
@@ -41,17 +40,15 @@ export default function AffinityBar({ level = 0, streak = 0, description }) {
           className={`${styles.heartWrapper} ${isAnimated ? styles.heartAnimated : ''}`}
           style={{ animationDelay: `${i * 100}ms` }}
         >
-          <Image
-            src="/icon/heart.svg"
-            alt=""
-            width={20}
-            height={20}
+          <svg 
+            width="20" 
+            height="20" 
+            viewBox="0 0 24 24" 
             className={styles.heartIcon}
-            style={{ 
-              color: getHeartColor(i, level),
-              fill: getHeartColor(i, level)
-            }}
-          />
+            style={{ fill: getHeartColor(i, level) }}
+          >
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>
+          </svg>
         </div>
       );
     }


### PR DESCRIPTION
## Summary
Next.js ImageコンポーネントをSVGエレメントに変更し、ハートの色が正しく反映されるように修正

## Problem
- Next.js の `Image` コンポーネントでSVGファイルを読み込んでも、CSS の `color` や `fill` プロパティが反映されない
- 親密度レベルに応じたハートの色変化が表示されていなかった

## Solution
- `Image` コンポーネントを削除し、インライン SVG エレメントに変更
- `fill` 属性で動的に色を設定できるように修正
- SVG パスを直接埋め込んでパフォーマンスも向上

## Changes

### Before
```jsx
<Image
  src="/icon/heart.svg"
  alt=""
  width={20}
  height={20}
  className={styles.heartIcon}
  style={{ 
    color: getHeartColor(i, level),
    fill: getHeartColor(i, level)  // 効果なし
  }}
/>
```

### After
```jsx
<svg 
  width="20" 
  height="20" 
  viewBox="0 0 24 24" 
  className={styles.heartIcon}
  style={{ fill: getHeartColor(i, level) }}  // 正しく反映
>
  <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>
</svg>
```

## Benefits
- ✅ 色の動的変更が正しく動作
- ✅ パフォーマンス改善（外部ファイル読み込み不要）
- ✅ より軽量なコード
- ✅ ブラウザ互換性の向上

## Test Plan
- [ ] 親密度0で1個目のハートがグレー（`#E5E5E5`）で表示
- [ ] 親密度10で1個目のハートが指定ピンク（`rgb(248, 144, 182)`）で表示
- [ ] 部分的な塗りつぶし（例：親密度15）で薄いピンク（`rgb(255, 229, 239)`）で表示
- [ ] 各ハートのアニメーション効果が正常に動作

🤖 Generated with [Claude Code](https://claude.ai/code)