### PR TITLE
管理画面のCSSインポートパス修正

### DIFF
--- a/frontend/app/admin/dashboard/page.js
+++ b/frontend/app/admin/dashboard/page.js
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useAdminAuth } from '@/utils/adminAuth';
 import api from '@/utils/api';
 import GlobalLoading from '@/components/GlobalLoading';
-import '../../../styles/admin-design-system.css';
+import '../../styles/admin-design-system.css';
 
 export default function AdminDashboard() {
   const { admin } = useAdminAuth();

--- a/frontend/app/admin/users/page.js
+++ b/frontend/app/admin/users/page.js
@@ -5,7 +5,7 @@ import { useAdminAuth } from '@/utils/adminAuth';
 import api from '@/utils/api';
 import GlobalLoading from '@/components/GlobalLoading';
 import Card from '@/components/Card';
-import '../../../styles/admin-design-system.css';
+import '../../styles/admin-design-system.css';
 
 export default function AdminUsers() {
   const { admin } = useAdminAuth();


### PR DESCRIPTION
## Summary
管理画面でのCSSインポートパスエラーを修正

## Problem
```
Module not found: Can't resolve '../../../styles/admin-design-system.css'
```

管理画面ページ（admin/dashboard, admin/users）でCSSファイルへの相対パスが間違っており、ビルドエラーが発生していました。

## Solution
相対パスを正しく修正：

### Before
```javascript
import '../../../styles/admin-design-system.css';  // ❌ 間違ったパス
```

### After  
```javascript
import '../../styles/admin-design-system.css';     // ✅ 正しいパス
```

## Files Changed
- `frontend/app/admin/dashboard/page.js`: CSSインポートパス修正
- `frontend/app/admin/users/page.js`: CSSインポートパス修正

## Path Structure
```
frontend/app/
├── admin/
│   ├── dashboard/page.js  ← ここから
│   └── users/page.js      ← ここから
└── styles/
    └── admin-design-system.css  ← ここへ (../../styles/)
```

## Test
- ✅ ビルドエラーが解消されることを確認
- ✅ 管理画面のスタイルが正しく適用されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)