### PR TITLE
背景色を青のグラデーションに戻す

### DIFF
--- a/frontend/app/[locale]/dashboard/dashboard.module.css
+++ b/frontend/app/[locale]/dashboard/dashboard.module.css
@@ -1,7 +1,7 @@
 /* ルート */
 .dashboardRoot {
   min-height: 100vh;
-  background: #ffffff;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   position: relative;
   overflow-x: hidden;
 }

--- a/frontend/app/styles/pages/mypage.css
+++ b/frontend/app/styles/pages/mypage.css
@@ -1,7 +1,7 @@
 /* マイページのスタイル */
 .mypage {
   min-height: 100vh;
-  background: #ffffff;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   position: relative;
 }
 

--- a/frontend/app/styles/pages/purchase.css
+++ b/frontend/app/styles/pages/purchase.css
@@ -2,7 +2,7 @@
 
 .purchase-root {
   min-height: 100vh;
-  background: #ffffff;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   position: relative;
 }
 


### PR DESCRIPTION
## Summary
- 白背景では見えにくいため、各ページの背景色を青のグラデーションに戻す
- UI改善の一環で背景を白に変更したが、視認性の問題で元の青グラデーションに復元

## 変更箇所
- dashboard: 白背景 → 青グラデーション背景
- mypage: 白背景 → 青グラデーション背景  
- purchase: 白背景 → 青グラデーション背景

## Test plan
- [x] ダッシュボードページの背景確認
- [x] マイページの背景確認
- [x] 購入ページの背景確認
- [x] 視認性の改善を確認

🤖 Generated with [Claude Code](https://claude.ai/code)