### PR TITLE
シークレット画像のはみ出し問題を修正

### DIFF
--- a/frontend/app/[locale]/dashboard/dashboard.module.css
+++ b/frontend/app/[locale]/dashboard/dashboard.module.css
@@ -11,10 +11,12 @@
 .sliderContainer {
   margin-bottom: 2rem;
   padding-top: 2rem;
+  padding-bottom: 2rem;
   border-radius: 0 0 2rem 2rem;
   overflow: hidden;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
   background: white;
+  position: relative;
 }
 
 /* ダッシュボードコンテナ */

--- a/frontend/app/components/ImageSlider.module.css
+++ b/frontend/app/components/ImageSlider.module.css
@@ -11,6 +11,7 @@
   width: 100%;
   overflow: hidden;
   border-radius: 8px;
+  position: relative;
 }
 
 .carouselTrack {
@@ -132,7 +133,9 @@
 .imageWrapper {
   position: relative;
   width: 100%;
-  height: 100%;
+  height: 280px;
+  overflow: hidden;
+  border-radius: 8px;
 }
 
 .lockedImage {


### PR DESCRIPTION
## Summary
- ダッシュボードのスライダーコンテナでシークレット画像が下にはみ出している問題を修正
- sliderContainerに下部padding（2rem）とposition: relativeを追加
- imageWrapperに固定の高さ制約とoverflow: hiddenを設定

## Test plan
- ダッシュボードでシークレット画像（ロックされた画像）が適切に表示されることを確認
- 画像が下方向にはみ出さないことを確認
- スライダーの動作が正常に機能することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)