### PR TITLE
serverExternalPackagesエラーを修正

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -6,7 +6,9 @@ const nextConfig = {
   images: {
     domains: ['localhost'],
   },
-  serverExternalPackages: ['mongoose'],
+  experimental: {
+    serverComponentsExternalPackages: ['mongoose'],
+  },
   async rewrites() {
     return [
       {


### PR DESCRIPTION
## Summary
- 廃止されたserverExternalPackagesをexperimental.serverComponentsExternalPackagesに変更
- Next.js 14.1.0の新しい設定に準拠してビルド時の警告を解消

## Test plan
- [x] フロントエンドビルドが警告なしで正常に完了することを確認
- [x] 開発サーバーが警告なしで正常に起動することを確認
- [x] Next.js 14の推奨設定に準拠していることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)