### PR TITLE
キャラクター編集画面のレイアウトを縦並びに改善

### DIFF
--- a/frontend/app/admin/characters/[id]/edit/page.js
+++ b/frontend/app/admin/characters/[id]/edit/page.js
@@ -291,56 +291,54 @@ export default function EditCharacter({ params }) {
               </h2>
               <p className={styles.sectionDescription}>キャラクターの基本的な情報を設定します</p>
             </div>
-            <div className={styles.formGridTwoColumns}>
-              <div className={styles['admin-form-group']}>
-                <label className={styles['admin-form-label']}>キャラクター名</label>
-                <div className={styles.languageTabs}>
-                  <div className={styles.languageTab}>
-                    <div className={styles.languageLabel}>
-                      <span className={styles.languageFlag}>🇯🇵</span>
-                      日本語
-                    </div>
-                    <input
-                      id="name.ja"
-                      name="name.ja"
-                      value={formData.name.ja}
-                      onChange={handleChange}
-                      required
-                      className={styles['admin-form-input']}
-                    />
+            <div className={styles['admin-form-group']}>
+              <label className={styles['admin-form-label']}>キャラクター名</label>
+              <div className={styles.languageTabs}>
+                <div className={styles.languageTab}>
+                  <div className={styles.languageLabel}>
+                    <span className={styles.languageFlag}>🇯🇵</span>
+                    日本語
                   </div>
-                  <div className={styles.languageTab}>
-                    <div className={styles.languageLabel}>
-                      <span className={styles.languageFlag}>🇺🇸</span>
-                      English
-                    </div>
-                    <input
-                      id="name.en"
-                      name="name.en"
-                      value={formData.name.en}
-                      onChange={handleChange}
-                      className={styles['admin-form-input']}
-                    />
-                  </div>
-                </div>
-              </div>
-              <div className={styles['admin-form-group']}>
-                <label htmlFor="themeColor" className={styles['admin-form-label']}>テーマカラー</label>
-                <div className={styles.themeColorGroup}>
                   <input
-                    type="color"
-                    id="themeColor"
-                    value={formData.themeColor}
+                    id="name.ja"
+                    name="name.ja"
+                    value={formData.name.ja}
                     onChange={handleChange}
-                    className={styles.colorPicker}
+                    required
+                    className={styles['admin-form-input']}
                   />
+                </div>
+                <div className={styles.languageTab}>
+                  <div className={styles.languageLabel}>
+                    <span className={styles.languageFlag}>🇺🇸</span>
+                    English
+                  </div>
                   <input
-                    value={formData.themeColor}
+                    id="name.en"
+                    name="name.en"
+                    value={formData.name.en}
                     onChange={handleChange}
                     className={styles['admin-form-input']}
-                    style={{ flex: 1 }}
                   />
                 </div>
+              </div>
+            </div>
+            <div className={styles['admin-form-group']}>
+              <label htmlFor="themeColor" className={styles['admin-form-label']}>テーマカラー</label>
+              <div className={styles.themeColorGroup}>
+                <input
+                  type="color"
+                  id="themeColor"
+                  value={formData.themeColor}
+                  onChange={handleChange}
+                  className={styles.colorPicker}
+                />
+                <input
+                  value={formData.themeColor}
+                  onChange={handleChange}
+                  className={styles['admin-form-input']}
+                  style={{ flex: 1 }}
+                />
               </div>
             </div>
             <div className={styles['admin-form-group']}>
@@ -562,93 +560,91 @@ export default function EditCharacter({ params }) {
               </h2>
               <p className={styles.sectionDescription}>キャラクターの画像と音声を設定します</p>
             </div>
-            <div className={styles.formGridTwoColumns}>
-              <div className={styles['media-upload-section']}>
-                <div className={styles['media-upload-label']}>
-                  👤 キャラクター選択画面画像
-                </div>
-                {formData.imageCharacterSelect && (
-                  <img
-                    src={formData.imageCharacterSelect}
-                    alt="Character Select"
-                    className={styles['media-upload-preview']}
-                  />
-                )}
-                <label className={styles['media-upload-btn']}>
-                  📁 ファイルを選択
-                  <input
-                    type="file"
-                    accept="image/*"
-                    onChange={(e) => handleImageUpload(e, 'characterSelect')}
-                    className={styles['media-upload-file-input']}
-                  />
-                </label>
+            <div className={styles['media-upload-section']}>
+              <div className={styles['media-upload-label']}>
+                👤 キャラクター選択画面画像
               </div>
-              <div className={styles['media-upload-section']}>
-                <div className={styles['media-upload-label']}>
-                  📊 ダッシュボード画像
-                </div>
-                {formData.imageDashboard && (
-                  <img
-                    src={formData.imageDashboard}
-                    alt="Dashboard"
-                    className={styles['media-upload-preview']}
-                  />
-                )}
-                <label className={styles['media-upload-btn']}>
-                  📁 ファイルを選択
-                  <input
-                    type="file"
-                    accept="image/*"
-                    onChange={(e) => handleImageUpload(e, 'dashboard')}
-                    className={styles['media-upload-file-input']}
-                  />
-                </label>
-              </div>
-              <div className={styles['media-upload-section']}>
-                <div className={styles['media-upload-label']}>
-                  🖼️ チャット背景画像
-                </div>
-                {formData.imageChatBackground && (
-                  <img
-                    src={formData.imageChatBackground}
-                    alt="Chat Background"
-                    className={styles['media-upload-preview']}
-                  />
-                )}
-                <label className={styles['media-upload-btn']}>
-                  📁 ファイルを選択
-                  <input
-                    type="file"
-                    accept="image/*"
-                    onChange={(e) => handleImageUpload(e, 'chatBackground')}
-                    className={styles['media-upload-file-input']}
-                  />
-                </label>
-              </div>
-              <div className={styles['media-upload-section']}>
-                <div className={styles['media-upload-label']}>
-                  💬 チャットアバター画像
-                </div>
-                {formData.imageChatAvatar && (
-                  <img
-                    src={formData.imageChatAvatar}
-                    alt="Chat Avatar"
-                    className={styles['media-upload-preview']}
-                  />
-                )}
-                <label className={styles['media-upload-btn']}>
-                  📁 ファイルを選択
-                  <input
-                    type="file"
-                    accept="image/*"
-                    onChange={(e) => handleImageUpload(e, 'chatAvatar')}
-                    className={styles['media-upload-file-input']}
-                  />
-                </label>
-              </div>
+              {formData.imageCharacterSelect && (
+                <img
+                  src={formData.imageCharacterSelect}
+                  alt="Character Select"
+                  className={styles['media-upload-preview']}
+                />
+              )}
+              <label className={styles['media-upload-btn']}>
+                📁 ファイルを選択
+                <input
+                  type="file"
+                  accept="image/*"
+                  onChange={(e) => handleImageUpload(e, 'characterSelect')}
+                  className={styles['media-upload-file-input']}
+                />
+              </label>
             </div>
-            <div className={styles['media-upload-section']} style={{maxWidth:'400px'}}>
+            <div className={styles['media-upload-section']}>
+              <div className={styles['media-upload-label']}>
+                📊 ダッシュボード画像
+              </div>
+              {formData.imageDashboard && (
+                <img
+                  src={formData.imageDashboard}
+                  alt="Dashboard"
+                  className={styles['media-upload-preview']}
+                />
+              )}
+              <label className={styles['media-upload-btn']}>
+                📁 ファイルを選択
+                <input
+                  type="file"
+                  accept="image/*"
+                  onChange={(e) => handleImageUpload(e, 'dashboard')}
+                  className={styles['media-upload-file-input']}
+                />
+              </label>
+            </div>
+            <div className={styles['media-upload-section']}>
+              <div className={styles['media-upload-label']}>
+                🖼️ チャット背景画像
+              </div>
+              {formData.imageChatBackground && (
+                <img
+                  src={formData.imageChatBackground}
+                  alt="Chat Background"
+                  className={styles['media-upload-preview']}
+                />
+              )}
+              <label className={styles['media-upload-btn']}>
+                📁 ファイルを選択
+                <input
+                  type="file"
+                  accept="image/*"
+                  onChange={(e) => handleImageUpload(e, 'chatBackground')}
+                  className={styles['media-upload-file-input']}
+                />
+              </label>
+            </div>
+            <div className={styles['media-upload-section']}>
+              <div className={styles['media-upload-label']}>
+                💬 チャットアバター画像
+              </div>
+              {formData.imageChatAvatar && (
+                <img
+                  src={formData.imageChatAvatar}
+                  alt="Chat Avatar"
+                  className={styles['media-upload-preview']}
+                />
+              )}
+              <label className={styles['media-upload-btn']}>
+                📁 ファイルを選択
+                <input
+                  type="file"
+                  accept="image/*"
+                  onChange={(e) => handleImageUpload(e, 'chatAvatar')}
+                  className={styles['media-upload-file-input']}
+                />
+              </label>
+            </div>
+            <div className={styles['media-upload-section']}>
               <div className={styles['media-upload-label']}>
                 🎵 サンプル音声
               </div>

--- a/frontend/app/admin/characters/[id]/edit/page.module.css
+++ b/frontend/app/admin/characters/[id]/edit/page.module.css
@@ -286,6 +286,12 @@
   gap: 2rem;
 }
 
+.formGridSingleColumn {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: 1fr;
+}
+
 .formGridTwoColumns {
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
 }
@@ -300,6 +306,7 @@
   flex-direction: column;
   align-items: flex-start;
   transition: all 0.2s ease;
+  max-width: 100%;
 }
 
 .media-upload-section:hover {
@@ -574,6 +581,10 @@
   
   .formCard {
     padding: 1.5rem;
+  }
+  
+  .formGridSingleColumn {
+    gap: 1.5rem;
   }
   
   .formGridTwoColumns {


### PR DESCRIPTION
## Summary
- キャラクター編集画面の入力項目を縦並びレイアウトに変更し、入力・確認しやすいUIに改善
- 基本情報とメディア設定セクションを1列レイアウトに変更し、順序良く入力できるように調整

## Test plan
- [x] キャラクター編集ページの表示確認
- [x] 各入力項目の順序と配置が適切に縦並びになっていることを確認
- [x] フォーム入力とバリデーションの動作確認
- [x] レスポンシブデザインの確認（モバイル・タブレット・デスクトップ）
- [x] 既存の機能に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)