### PR TITLE
CSS優先度の問題を修正 - グローバルCSSがCSS Modulesを上書きしていた問題を解決

### DIFF
--- a/frontend/app/admin/characters/[id]/edit/page.module.css
+++ b/frontend/app/admin/characters/[id]/edit/page.module.css
@@ -45,37 +45,37 @@
 }
 
 .admin-form-label {
-  display: block;
-  font-size: 14px;
-  font-weight: 600;
-  color: #374151;
-  margin-bottom: 8px;
-  letter-spacing: 0.01em;
+  display: block !important;
+  font-size: 14px !important;
+  font-weight: 600 !important;
+  color: #374151 !important;
+  margin-bottom: 8px !important;
+  letter-spacing: 0.01em !important;
 }
 
 .admin-form-input {
-  width: 100%;
-  border-radius: 12px;
-  border: 1px solid #e2e8f0;
-  padding: 12px 16px;
-  font-size: 14px;
-  background: #f8fafc;
-  color: #1f2937;
-  margin-bottom: 8px;
-  transition: all 0.2s ease;
-  font-family: inherit;
-  line-height: 1.5;
+  width: 100% !important;
+  border-radius: 12px !important;
+  border: 1px solid #e2e8f0 !important;
+  padding: 12px 16px !important;
+  font-size: 14px !important;
+  background: #f8fafc !important;
+  color: #1f2937 !important;
+  margin-bottom: 8px !important;
+  transition: all 0.2s ease !important;
+  font-family: inherit !important;
+  line-height: 1.5 !important;
 }
 
 .admin-form-input:focus {
-  border-color: #3b82f6;
-  outline: none;
-  background: #fff;
-  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.1);
+  border-color: #3b82f6 !important;
+  outline: none !important;
+  background: #fff !important;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.1) !important;
 }
 
 .admin-form-input:hover {
-  border-color: #cbd5e1;
+  border-color: #cbd5e1 !important;
 }
 
 .admin-form-group {
@@ -115,33 +115,33 @@
 
 /* Language Tabs - Vertical Layout */
 .languageTabs {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
+  display: flex !important;
+  flex-direction: column !important;
+  gap: 1rem !important;
 }
 
 .languageTab {
-  background: white;
-  border: 1px solid #e2e8f0;
-  border-radius: 12px;
-  padding: 1rem;
-  transition: all 0.2s ease;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  background: white !important;
+  border: 1px solid #e2e8f0 !important;
+  border-radius: 12px !important;
+  padding: 1rem !important;
+  transition: all 0.2s ease !important;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1) !important;
 }
 
 .languageTab:hover {
-  border-color: #cbd5e1;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  border-color: #cbd5e1 !important;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1) !important;
 }
 
 .languageLabel {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: #64748b;
-  margin-bottom: 8px;
+  display: flex !important;
+  align-items: center !important;
+  gap: 0.5rem !important;
+  font-size: 0.875rem !important;
+  font-weight: 500 !important;
+  color: #64748b !important;
+  margin-bottom: 8px !important;
 }
 
 .languageFlag {


### PR DESCRIPTION
## 原因
- `/frontend/app/styles/admin-design-system.css`でグローバルに定義された`.admin-form-input`スタイル（491-504行目）がCSS Modulesのスタイルを上書きしていました
- CSS読み込み順序により、グローバルCSSが後から適用され、CSS Modulesの設定が無効化されていました

## 解決方法
- CSS Modulesの重要なスタイルに`\!important`を追加してグローバルCSSをオーバーライド
- `.admin-form-input`, `.admin-form-label`, `.languageTab`などのスタイルが確実に適用されるように修正

## Test plan
- [x] キャラクター編集ページで入力フィールドのスタイルが正しく適用されることを確認
- [x] 言語タブが縦並びで表示されることを確認
- [x] 入力フィールドの背景色とボーダーが設定通りに表示されることを確認
- [x] フォーカス・ホバー状態も正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)