### PR TITLE
ユーザー管理画面のテーブル表示で会員種別をバッジ形式に変更

### DIFF
--- a/frontend/app/admin/users/page.js
+++ b/frontend/app/admin/users/page.js
@@ -169,10 +169,10 @@ export default function AdminUsers() {
                       </div>
                     </td>
                     <td>
-                      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--admin-space-1)' }}>
-                        <div style={{ fontSize: 'var(--admin-font-size-sm)', fontWeight: '500' }}>
-                          {user.membershipType === 'subscription' ? 'サブスクリプション' : '無料プラン'}
-                        </div>
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--admin-space-2)' }}>
+                        <span className={`admin-badge ${user.membershipType === 'subscription' ? 'admin-badge--warning' : 'admin-badge--neutral'}`}>
+                          {user.membershipType === 'subscription' ? '🔥 プレミアム' : '🆓 無料'}
+                        </span>
                         {user.membershipType === 'subscription' && (
                           <div style={{ fontSize: 'var(--admin-font-size-xs)', color: 'var(--admin-gray-500)' }}>
                             状態: {user.subscriptionStatus || 'unknown'}


### PR DESCRIPTION
## Summary
- ユーザー管理画面のテーブル表示で会員種別をバッジ形式に統一
- 詳細モーダルと同じデザインパターンで視認性向上

## Test plan
- [x] ユーザー管理画面のテーブルで会員種別がバッジ表示されることを確認
- [x] プレミアム会員が🔥アイコン付きのwarningバッジで表示されることを確認  
- [x] 無料会員が🆓アイコン付きのneutralバッジで表示されることを確認
- [x] 詳細モーダルと統一されたデザインになっていることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)