### PR TITLE
ステータスバッジをアカウント状態に特化して重複を解消

### DIFF
--- a/frontend/app/admin/users/page.js
+++ b/frontend/app/admin/users/page.js
@@ -82,14 +82,11 @@ export default function AdminUsers() {
     );
   }
 
-  // ステータスバッジの取得
+  // アカウント状態バッジの取得
   const getStatusBadge = (user) => {
-    if (!user.isActive) return <span className="admin-badge admin-badge--error">無効</span>;
-    if (!user.hasCompletedSetup) return <span className="admin-badge admin-badge--warning">未完了</span>;
-    if (user.membershipType === 'subscription' && user.subscriptionStatus === 'active') {
-      return <span className="admin-badge admin-badge--success">プレミアム</span>;
-    }
-    return <span className="admin-badge admin-badge--neutral">無料</span>;
+    if (!user.isActive) return <span className="admin-badge admin-badge--error">❌ 無効</span>;
+    if (!user.hasCompletedSetup) return <span className="admin-badge admin-badge--warning">⚠️ セットアップ未完了</span>;
+    return <span className="admin-badge admin-badge--success">✅ 有効</span>;
   };
 
   // 親密度統計の計算
@@ -135,7 +132,7 @@ export default function AdminUsers() {
             <thead>
               <tr>
                 <th>ユーザー情報</th>
-                <th>ステータス</th>
+                <th>アカウント状態</th>
                 <th>会員種別</th>
                 <th>親密度統計</th>
                 <th>最終活動</th>


### PR DESCRIPTION
## Summary
- ステータスバッジを会員種別から分離してアカウント状態のみに特化
- 会員種別との重複表示を解消して情報を整理

## Changes
- ステータスバッジの表示内容を変更：
  - ❌ 無効（isActive = false）
  - ⚠️ セットアップ未完了（hasCompletedSetup = false）
  - ✅ 有効（その他）
- テーブルヘッダーを「ステータス」→「アカウント状態」に変更

## Test plan
- [x] アカウント無効ユーザーが「❌ 無効」で表示されることを確認
- [x] セットアップ未完了ユーザーが「⚠️ セットアップ未完了」で表示されることを確認  
- [x] 正常ユーザーが「✅ 有効」で表示されることを確認
- [x] 会員種別と重複しない独立した情報として表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)