### PR TITLE
showLeft/showRight関数のchatMessages未定義エラー修正

### DIFF
--- a/frontend/app/[locale]/page.js
+++ b/frontend/app/[locale]/page.js
@@ -260,11 +260,14 @@ export default function Home({ params }) {
   }, [displayedText]);
   
   useEffect(() => {
+    if (!chatMessages.length) return;
+    
     let isLeft = true;
     let currentIndex = 0;
     let leftTimeout, rightTimeout;
 
     function showLeft() {
+      if (!chatMessages[currentIndex]) return;
       setLeftText('');
       setLeftVisible(true);
       setRightVisible(false);
@@ -289,6 +292,7 @@ export default function Home({ params }) {
     }
 
     function showRight() {
+      if (!chatMessages[currentIndex]) return;
       setRightText('');
       setLeftVisible(false);
       setRightVisible(true);
@@ -317,7 +321,7 @@ export default function Home({ params }) {
       clearTimeout(leftTimeout);
       clearTimeout(rightTimeout);
     };
-  }, []);
+  }, [chatMessages]);
   
   if (loading) {
     return <GlobalLoading text={t('loading', '読み込み中...')} />;


### PR DESCRIPTION
## Summary
• ホームページの左右チャットバブル表示機能でのchatMessages未定義TypeErrorを修正
• showLeft/showRight関数にガード句を追加

## Test plan
- [ ] ホームページの左右チャットバブルアニメーションが正常に動作することを確認
- [ ] chatMessages読み込み前にエラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)