### PR TITLE
無料ユーザーの1日5回チャット制限機能を実装

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -31,7 +31,9 @@
       "Bash(ls:*)",
       "Bash(grep:*)",
       "Bash(npm run lint)",
-      "Bash(npm start)"
+      "Bash(npm start)",
+      "Bash(git fetch:*)",
+      "Bash(rg:*)"
     ]
   },
   "enableAllProjectMcpServers": false

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -86,6 +86,14 @@ const UserSchema = new Schema({
     type: String,
     default: null
   },
+  dailyChatCount: {
+    type: Number,
+    default: 0
+  },
+  lastChatResetDate: {
+    type: Date,
+    default: Date.now
+  },
   affinities: [{
     character: {
       type: Schema.Types.ObjectId,

--- a/backend/routes/admin/users.js
+++ b/backend/routes/admin/users.js
@@ -125,4 +125,32 @@ router.delete('/:id', adminAuth, async (req, res) => {
   }
 });
 
+router.put('/:id/reset-chat-count', adminAuth, async (req, res) => {
+  try {
+    const user = await User.findById(req.params.id);
+    
+    if (!user) {
+      return res.status(404).json({ msg: 'ユーザーが見つかりません' });
+    }
+    
+    user.dailyChatCount = 0;
+    user.lastChatResetDate = new Date();
+    await user.save();
+    
+    res.json({ 
+      msg: 'チャット回数がリセットされました',
+      dailyChatCount: user.dailyChatCount,
+      lastChatResetDate: user.lastChatResetDate
+    });
+  } catch (err) {
+    console.error(err.message);
+    
+    if (err.kind === 'ObjectId') {
+      return res.status(404).json({ msg: 'ユーザーが見つかりません' });
+    }
+    
+    res.status(500).send('サーバーエラー');
+  }
+});
+
 module.exports = router;

--- a/frontend/app/styles/chat.css
+++ b/frontend/app/styles/chat.css
@@ -402,4 +402,55 @@
   margin-right: 0;
   text-align: left;
   font-weight: 500;
+}
+
+/* チャット制限メッセージ */
+.chat-limit-message {
+  margin-bottom: 16px;
+  padding: 16px;
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.2);
+  border-radius: 12px;
+  text-align: center;
+}
+
+.chat-limit-content p {
+  color: #dc2626;
+  margin: 0 0 8px 0;
+  font-weight: 500;
+}
+
+.chat-limit-content p:last-of-type {
+  margin-bottom: 16px;
+}
+
+.chat-upgrade-button {
+  background: #dc2626;
+  color: white;
+  border: none;
+  padding: 12px 24px;
+  border-radius: 8px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  box-shadow: 0 4px 12px rgba(220, 38, 38, 0.3);
+}
+
+.chat-upgrade-button:hover {
+  background: #b91c1c;
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(220, 38, 38, 0.4);
+}
+
+/* 残りチャット回数表示 */
+.chat-remaining-counter {
+  margin-bottom: 12px;
+  padding: 8px 16px;
+  background: rgba(59, 130, 246, 0.1);
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  border-radius: 8px;
+  text-align: center;
+  color: #1d4ed8;
+  font-size: 14px;
+  font-weight: 500;
 } 


### PR DESCRIPTION
## 概要
無料会員のチャット利用を1日5回に制限する機能を実装しました。制限に達した場合はプレミアム会員への誘導を表示します。

## 主な変更内容
- **User モデル**: `dailyChatCount` と `lastChatResetDate` フィールドを追加
- **チャット API**: 無料会員の制限チェックとカウンタ更新を実装
- **チャット画面**: 制限メッセージと残り回数表示を追加
- **管理画面**: テスト用のチャット回数リセット機能を追加

## 実装の詳細

### バックエンド
- `/backend/models/User.js`: チャット回数とリセット日フィールドを追加
- `/backend/routes/chat.js`: 無料会員の制限チェック・カウント処理
- `/backend/routes/admin/users.js`: 管理者向けリセット API を追加

### フロントエンド
- `/frontend/app/[locale]/chat/page.js`: 制限メッセージ・残り回数表示・入力制御
- `/frontend/app/admin/users/page.js`: 管理画面にリセットボタンを追加
- `/frontend/app/styles/chat.css`: 制限関連 UI のスタイルを追加

## テスト確認項目
- [ ] 無料会員が5回チャット後に制限メッセージが表示される
- [ ] 制限に達した場合入力が無効化される
- [ ] 日付が変わると自動的にカウントがリセットされる
- [ ] 管理画面でリセットボタンが正常に動作する
- [ ] プレミアム会員は制限を受けない

## 注意事項
- チャット回数リセット機能はテスト用として実装
- 将来的にはこの機能は削除予定

🤖 Generated with [Claude Code](https://claude.ai/code)