### PR TITLE
チャット制限のUX改善とAIキャラからの制限メッセージ機能を実装

### DIFF
--- a/frontend/app/[locale]/chat/page.js
+++ b/frontend/app/[locale]/chat/page.js
@@ -53,6 +53,15 @@ export default function Chat({ params }) {
             const historyMessages = res.data.messages || [];
             setMessages(historyMessages);
             setChatId(res.data._id);
+            
+            // チャット制限状態を設定
+            if (res.data.isLimitReached !== undefined) {
+              setChatLimitReached(res.data.isLimitReached);
+            }
+            if (res.data.remainingChats !== undefined) {
+              setRemainingChats(res.data.remainingChats);
+            }
+            
             if (historyMessages.length === 0 && user.selectedCharacter.defaultMessage) {
               const defaultMessage = {
                 sender: 'ai',
@@ -350,13 +359,15 @@ export default function Chat({ params }) {
           {chatLimitReached && (
             <div className="chat-limit-message">
               <div className="chat-limit-content">
-                <p>無料会員は1日5回までチャットできます。</p>
-                <p>プレミアム会員になると制限が解除されます。</p>
+                <div className="chat-limit-icon">😅</div>
+                <h3 className="chat-limit-title">1日の無料チャット回数に達しました</h3>
+                <p>プレミアム会員になると、もっとたくさん会話ができます。</p>
+                <p>いつでもキャラクターと無制限でお話しできるように、ぜひプレミアム会員をご検討ください！</p>
                 <button 
                   className="chat-upgrade-button"
                   onClick={() => router.push(`/${locale}/purchase`)}
                 >
-                  プレミアム会員になる
+                  🌟 プレミアム会員になる
                 </button>
               </div>
             </div>
@@ -365,7 +376,10 @@ export default function Chat({ params }) {
           {/* 残りチャット回数表示（無料会員のみ） */}
           {!chatLimitReached && user?.membershipType === 'free' && remainingChats !== null && (
             <div className="chat-remaining-counter">
-              今日あと {remainingChats} 回チャットできます
+              💬 今日あと <strong>{remainingChats}</strong> 回チャットできます
+              {remainingChats <= 2 && (
+                <span className="chat-remaining-warning"> • プレミアム会員で無制限に！</span>
+              )}
             </div>
           )}
           

--- a/frontend/app/[locale]/dashboard/dashboard.module.css
+++ b/frontend/app/[locale]/dashboard/dashboard.module.css
@@ -413,3 +413,47 @@
   border-radius: 32px;
   backdrop-filter: blur(20px);
 }
+
+/* チャット制限関連スタイル */
+.limitReached {
+  text-align: center;
+}
+
+.limitText {
+  color: #dc2626;
+  font-weight: 600;
+  margin: 0 0 16px 0;
+  font-size: 1rem;
+}
+
+.upgradeButtonSmall {
+  background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+  color: white;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  box-shadow: 0 4px 12px rgba(245, 158, 11, 0.3);
+}
+
+.upgradeButtonSmall:hover {
+  background: linear-gradient(135deg, #d97706 0%, #b45309 100%);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(245, 158, 11, 0.4);
+}
+
+.remainingText {
+  color: #1d4ed8;
+  font-weight: 500;
+  margin: 0;
+  line-height: 1.6;
+}
+
+.warningText {
+  color: #f59e0b;
+  font-weight: 600;
+  font-size: 0.9rem;
+}

--- a/frontend/app/styles/chat.css
+++ b/frontend/app/styles/chat.css
@@ -407,50 +407,80 @@
 /* チャット制限メッセージ */
 .chat-limit-message {
   margin-bottom: 16px;
-  padding: 16px;
-  background: rgba(239, 68, 68, 0.1);
-  border: 1px solid rgba(239, 68, 68, 0.2);
-  border-radius: 12px;
+  padding: 20px;
+  background: linear-gradient(135deg, rgba(255, 241, 241, 0.95) 0%, rgba(254, 226, 226, 0.95) 100%);
+  border: 2px solid rgba(239, 68, 68, 0.2);
+  border-radius: 16px;
   text-align: center;
+  box-shadow: 0 8px 32px rgba(239, 68, 68, 0.1);
+  backdrop-filter: blur(10px);
+}
+
+.chat-limit-icon {
+  font-size: 3rem;
+  margin-bottom: 12px;
+  display: block;
+}
+
+.chat-limit-title {
+  color: #dc2626;
+  margin: 0 0 16px 0;
+  font-weight: 700;
+  font-size: 1.25rem;
 }
 
 .chat-limit-content p {
-  color: #dc2626;
-  margin: 0 0 8px 0;
+  color: #7c2d12;
+  margin: 0 0 12px 0;
   font-weight: 500;
+  line-height: 1.6;
 }
 
 .chat-limit-content p:last-of-type {
-  margin-bottom: 16px;
+  margin-bottom: 20px;
 }
 
 .chat-upgrade-button {
-  background: #dc2626;
+  background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
   color: white;
   border: none;
-  padding: 12px 24px;
-  border-radius: 8px;
-  font-weight: 600;
+  padding: 14px 28px;
+  border-radius: 12px;
+  font-weight: 700;
+  font-size: 1.1rem;
   cursor: pointer;
-  transition: all 0.2s;
-  box-shadow: 0 4px 12px rgba(220, 38, 38, 0.3);
+  transition: all 0.3s ease;
+  box-shadow: 0 6px 20px rgba(245, 158, 11, 0.4);
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
 .chat-upgrade-button:hover {
-  background: #b91c1c;
-  transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(220, 38, 38, 0.4);
+  background: linear-gradient(135deg, #d97706 0%, #b45309 100%);
+  transform: translateY(-3px);
+  box-shadow: 0 10px 30px rgba(245, 158, 11, 0.5);
 }
 
 /* 残りチャット回数表示 */
 .chat-remaining-counter {
   margin-bottom: 12px;
-  padding: 8px 16px;
-  background: rgba(59, 130, 246, 0.1);
+  padding: 10px 16px;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.1) 0%, rgba(37, 99, 235, 0.1) 100%);
   border: 1px solid rgba(59, 130, 246, 0.2);
-  border-radius: 8px;
+  border-radius: 10px;
   text-align: center;
   color: #1d4ed8;
   font-size: 14px;
   font-weight: 500;
+  box-shadow: 0 2px 8px rgba(59, 130, 246, 0.1);
+}
+
+.chat-remaining-warning {
+  color: #f59e0b;
+  font-weight: 600;
+  animation: subtle-pulse 2s ease-in-out infinite;
+}
+
+@keyframes subtle-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.7; }
 } 


### PR DESCRIPTION
## 概要
無料会員のチャット制限機能のユーザーエクスペリエンスを大幅に改善し、5回制限後にAIキャラクターから親しみやすい制限メッセージが表示される機能を実装しました。

## 修正した問題
- ✅ 画面遷移時にチャット制限状態が消える問題を修正
- ✅ 制限に達した理由がユーザーに分からない問題を解決
- ✅ AIキャラクターからの制限メッセージが表示されない問題を修正

## 主な改善内容

### 1. 状態管理の改善
- チャット履歴取得時に制限状態も一緒に返すように変更
- 画面遷移してもチャット制限状態が維持される

### 2. AIキャラクターからの制限メッセージ
- 5回制限に達した際、AIキャラクターから親しみやすい制限メッセージを表示
- キャラクター名を含んだパーソナライズされたメッセージ
- 絵文字を使った親近感のあるトーン

### 3. プレミアム誘導の改善
- より魅力的で説得力のあるメッセージに変更
- 視覚的に目立つデザインに改善
- ホバーエフェクトとアニメーション追加

### 4. ダッシュボード連携
- ダッシュボードにもチャット制限情報を表示
- 無料会員向けの統一されたUX提供

### 5. 警告表示の追加
- 残りチャット回数が2回以下の時に警告表示
- プレミアム会員への誘導を段階的に実施

## 技術的な変更

### バックエンド
- `/backend/routes/chat.js`: GET API でも制限状態をチェック・返却
- チャット履歴に制限メッセージを自動追加する機能

### フロントエンド  
- `/frontend/app/[locale]/chat/page.js`: 制限状態の永続化
- `/frontend/app/[locale]/dashboard/page.js`: ダッシュボードに制限情報表示
- `/frontend/app/styles/chat.css`: UIデザインの大幅改善

## UIの改善点
- 🎨 グラデーション背景とブラー効果
- ✨ ホバーアニメーションと視覚効果
- 📱 レスポンシブデザイン対応
- 🎯 より直感的で分かりやすいメッセージ

## テスト確認項目
- [ ] 5回チャット後にAIキャラから制限メッセージが表示される
- [ ] 画面遷移しても制限状態が維持される
- [ ] ダッシュボードで制限情報が正しく表示される
- [ ] 残り回数が少ない時に警告が表示される
- [ ] プレミアム誘導ボタンが正常に動作する

🤖 Generated with [Claude Code](https://claude.ai/code)