### PR TITLE
管理画面設定の制限メッセージを使用するように修正

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -33,7 +33,8 @@
       "Bash(npm run lint)",
       "Bash(npm start)",
       "Bash(git fetch:*)",
-      "Bash(rg:*)"
+      "Bash(rg:*)",
+      "Bash(/home/jun/.nvm/versions/node/v22.16.0/lib/node_modules/@anthropic-ai/claude-code/vendor/ripgrep/x64-linux/rg \"制限メッセージ|limitMessage\" /home/jun/projects/ai-character/backend/routes/chat.js -n)"
     ]
   },
   "enableAllProjectMcpServers": false

--- a/backend/routes/chat.js
+++ b/backend/routes/chat.js
@@ -73,10 +73,13 @@ router.get('/', auth, async (req, res) => {
     
     // 制限に達した場合、制限メッセージをチャット履歴に追加
     if (isLimitReached && user.membershipType === 'free') {
-      const characterName = getString(character.name, user.preferredLanguage || 'ja');
+      const locale = user.preferredLanguage || 'ja';
+      // 管理画面で設定された制限メッセージを取得
+      const adminLimitMessage = getString(character.limitMessage, locale);
+      
       const limitMessage = {
         sender: 'ai',
-        content: `申し訳ありません…😢 無料会員の方は1日5回までしかお話しできないんです。\n\nでも、プレミアム会員になってくれたら、私と無制限でお話しできますよ！✨\n\n${characterName}と一緒にもっとたくさんお話ししませんか？ お待ちしています💕`,
+        content: adminLimitMessage || `申し訳ありませんが、無料会員の方は1日5回までしかチャットできません。プレミアム会員になると無制限でお話しできるようになります。`,
         timestamp: new Date(),
         isLimitMessage: true
       };


### PR DESCRIPTION
## 概要
固定の制限メッセージを削除し、管理画面で設定された「🇯🇵制限メッセージ（日本語）」を使用するように修正しました。

## 修正内容

### 変更前の問題
- チャット制限時のメッセージが固定文言でハードコーディングされていた
- キャラクターの個性に合わせたメッセージが表示できなかった
- 管理画面で設定した制限メッセージが使用されていなかった

### 変更後の改善
- `character.limitMessage` から適切な言語のメッセージを取得
- 日本語・英語それぞれの制限メッセージに対応
- キャラクターごとに個性に合わせたメッセージ表示が可能
- フォールバック用のシンプルなメッセージも設定

## 技術的な変更

### `/backend/routes/chat.js`
- 固定文言を削除
- `getString(character.limitMessage, locale)` でメッセージ取得
- 管理画面設定が空の場合のフォールバックメッセージを追加

## 使用方法
1. 管理画面のキャラクター編集ページで「🇯🇵制限メッセージ（日本語）」を設定
2. 無料会員が5回制限に達した際、設定されたメッセージが表示される
3. 未設定の場合はデフォルトの制限メッセージが表示される

## テスト確認項目
- [ ] 管理画面で設定した制限メッセージが正しく表示される
- [ ] 日本語・英語の言語設定に応じて適切なメッセージが表示される
- [ ] 制限メッセージが未設定の場合、フォールバックメッセージが表示される
- [ ] キャラクターごとに異なるメッセージが正しく表示される

🤖 Generated with [Claude Code](https://claude.ai/code)