### PR TITLE
フォールバックメッセージを削除してDBの制限メッセージのみ表示

### DIFF
--- a/backend/routes/chat.js
+++ b/backend/routes/chat.js
@@ -77,18 +77,21 @@ router.get('/', auth, async (req, res) => {
       // 管理画面で設定された制限メッセージを取得
       const adminLimitMessage = getString(character.limitMessage, locale);
       
-      const limitMessage = {
-        sender: 'ai',
-        content: adminLimitMessage || `申し訳ありませんが、無料会員の方は1日5回までしかチャットできません。プレミアム会員になると無制限でお話しできるようになります。`,
-        timestamp: new Date(),
-        isLimitMessage: true
-      };
-      
-      // 既に制限メッセージがある場合は追加しない
-      const hasLimitMessage = chat.messages.some(msg => msg.isLimitMessage);
-      if (!hasLimitMessage) {
-        chat.messages.push(limitMessage);
-        await chat.save();
+      // DBに制限メッセージが設定されている場合のみ表示
+      if (adminLimitMessage && adminLimitMessage.trim()) {
+        const limitMessage = {
+          sender: 'ai',
+          content: adminLimitMessage,
+          timestamp: new Date(),
+          isLimitMessage: true
+        };
+        
+        // 既に制限メッセージがある場合は追加しない
+        const hasLimitMessage = chat.messages.some(msg => msg.isLimitMessage);
+        if (!hasLimitMessage) {
+          chat.messages.push(limitMessage);
+          await chat.save();
+        }
       }
     }
     


### PR DESCRIPTION
## 概要
固定のフォールバックメッセージを削除し、管理画面で設定されたDBの制限メッセージのみを表示するように修正しました。

## 修正した問題
- フォールバック用の固定メッセージが表示されていた
- 管理画面で制限メッセージを設定していない場合も固定メッセージが表示されていた
- キャラクターの個性に合わないメッセージが表示される問題

## 変更内容

### 変更前
```javascript
content: adminLimitMessage || `申し訳ありませんが、無料会員の方は1日5回までしかチャットできません。プレミアム会員になると無制限でお話しできるようになります。`
```
- 管理画面未設定時に固定メッセージが表示されていた

### 変更後
```javascript
// DBに制限メッセージが設定されている場合のみ表示
if (adminLimitMessage && adminLimitMessage.trim()) {
  const limitMessage = {
    sender: 'ai',
    content: adminLimitMessage,
    timestamp: new Date(),
    isLimitMessage: true
  };
  // メッセージ追加処理
}
```
- DBで設定された制限メッセージのみ表示
- 未設定の場合は制限メッセージ自体を表示しない

## 動作仕様

### 管理画面で制限メッセージが設定されている場合
- 設定されたメッセージがAIキャラクターから表示される
- キャラクターの個性に合わせたメッセージ表示が可能

### 管理画面で制限メッセージが未設定の場合
- 制限メッセージは表示されない
- チャット入力欄の制限表示のみ表示される

## 技術的な変更
- `/backend/routes/chat.js`: フォールバックメッセージの削除
- 制限メッセージ存在チェックの追加 (`adminLimitMessage && adminLimitMessage.trim()`)

## テスト確認項目
- [ ] 管理画面で制限メッセージを設定した場合、そのメッセージが表示される
- [ ] 管理画面で制限メッセージを未設定の場合、AIからのメッセージは表示されない
- [ ] 固定のフォールバックメッセージが表示されない
- [ ] チャット入力欄の制限表示は正常に動作する

🤖 Generated with [Claude Code](https://claude.ai/code)