### PR TITLE
リロード時limitMessage問題を修正

### DIFF
--- a/frontend/app/[locale]/chat/page.js
+++ b/frontend/app/[locale]/chat/page.js
@@ -78,14 +78,12 @@ export default function Chat({ params }) {
               setRemainingChats(res.data.remainingChats);
             }
             
-            // 制限メッセージをチェック（制限に達している場合、メッセージ履歴に制限メッセージがあるかも）
-            if (res.data.isLimitReached) {
-              // 最新の制限メッセージを検索
-              const limitMessages = historyMessages.filter(msg => msg.isLimitMessage);
-              if (limitMessages.length > 0) {
-                const latestLimitMessage = limitMessages[limitMessages.length - 1];
-                setLimitMessage(latestLimitMessage.content);
-              }
+            // 制限メッセージを設定（APIレスポンスから取得）
+            if (res.data.limitMessage !== undefined) {
+              console.log('===== LIMIT MESSAGE DEBUG (RELOAD) =====');
+              console.log('Setting limitMessage from API:', res.data.limitMessage);
+              console.log('========================================');
+              setLimitMessage(res.data.limitMessage);
             }
             
             if (historyMessages.length === 0 && user.selectedCharacter.defaultMessage) {


### PR DESCRIPTION
## Summary
- チャット画面リロード時に古い「ああああテスト」が表示される問題を修正
- メッセージ履歴ではなくAPIレスポンスから最新制限メッセージを取得

## 問題の原因
- リロード時にメッセージ履歴の古い`isLimitMessage`から制限メッセージを取得していた
- 管理画面で更新した最新メッセージが反映されなかった

## 修正内容
- APIレスポンスの`limitMessage`を直接使用するように変更
- デバッグログを追加して動作確認を可能に

## Test plan
- [ ] チャット制限に達した後、リロードして正しいメッセージが表示されることを確認
- [ ] 管理画面で制限メッセージを変更後、リロードで反映されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)