### PR TITLE
キャラクター詳細画面に制限メッセージ表示を追加

### DIFF
--- a/frontend/app/admin/characters/[id]/detail/page.js
+++ b/frontend/app/admin/characters/[id]/detail/page.js
@@ -251,6 +251,22 @@ export default function CharacterDetailPage() {
                     {character.defaultMessage?.en || '-'}
                   </div>
                 </div>
+                <div className={styles.fieldGroup}>
+                  <div className={styles.fieldLabel}>
+                    制限メッセージ（日本語）
+                  </div>
+                  <div className={styles.fieldTextArea}>
+                    {character.limitMessage?.ja || '-'}
+                  </div>
+                </div>
+                <div className={styles.fieldGroup}>
+                  <div className={styles.fieldLabel}>
+                    制限メッセージ（英語）
+                  </div>
+                  <div className={styles.fieldTextArea}>
+                    {character.limitMessage?.en || '-'}
+                  </div>
+                </div>
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
- キャラクター詳細画面に制限メッセージの表示機能を追加
- 編集画面との一貫性を向上

## 変更内容
- AI設定カードに制限メッセージ（日本語・英語）の表示項目を追加
- 管理者が詳細画面でも制限メッセージの設定内容を確認可能

## Test plan
- [ ] キャラクター詳細画面で制限メッセージが正しく表示されることを確認
- [ ] 日本語・英語両方の制限メッセージが表示されることを確認
- [ ] 制限メッセージが未設定の場合に「-」が表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)