### PR TITLE
ハンバーガーメニューアイコンを明確なSVGアイコンに変更

### DIFF
--- a/frontend/app/components/core/TopBar.js
+++ b/frontend/app/components/core/TopBar.js
@@ -97,7 +97,21 @@ const TopBar = ({
           onClick={onContextToggle}
           title="メニューを開く"
         >
-          <span className={styles.hamburger}></span>
+          <svg 
+            className={styles.hamburger}
+            width="24" 
+            height="24" 
+            viewBox="0 0 24 24" 
+            fill="none"
+          >
+            <path 
+              d="M3 6h18M3 12h18M3 18h18" 
+              stroke="currentColor" 
+              strokeWidth="2" 
+              strokeLinecap="round" 
+              strokeLinejoin="round"
+            />
+          </svg>
         </button>
         
         <div className={styles.contextInfo}>

--- a/frontend/app/components/core/TopBar.module.css
+++ b/frontend/app/components/core/TopBar.module.css
@@ -43,31 +43,12 @@
 }
 
 .hamburger {
-  width: 20px;
-  height: 2px;
-  background: #64748b;
-  border-radius: 1px;
-  position: relative;
-  transition: all 0.3s ease;
+  color: #64748b;
+  transition: all 0.2s ease;
 }
 
-.hamburger::before,
-.hamburger::after {
-  content: '';
-  position: absolute;
-  width: 20px;
-  height: 2px;
-  background: #64748b;
-  border-radius: 1px;
-  transition: all 0.3s ease;
-}
-
-.hamburger::before {
-  top: -6px;
-}
-
-.hamburger::after {
-  bottom: -6px;
+.contextToggle:hover .hamburger {
+  color: #0f172a;
 }
 
 .contextInfo {


### PR DESCRIPTION
## Summary
- TopBar.jsでCSS擬似要素のハンバーガーをSVGアイコンに置き換え
- 3本の横線による分かりやすいハンバーガーメニューアイコン
- ホバー時の色変化も適切に動作するように調整

## Test plan
- [x] ハンバーガーメニューアイコンが明確に表示される
- [x] ホバー時の色変化が正常に動作する
- [x] クリック時にコンテキストパネルが開く

🤖 Generated with [Claude Code](https://claude.ai/code)