### PR TITLE
チャット画面のヘッダーにキャラアイコンと親密度表示を統合

### DIFF
--- a/frontend/app/components/core/ContextPanel.js
+++ b/frontend/app/components/core/ContextPanel.js
@@ -67,39 +67,6 @@ const ContextPanel = ({
         return (
           <>
             <div className={styles.section}>
-              <h4>現在のキャラクター</h4>
-              {user?.selectedCharacter ? (
-                <div className={styles.characterCard}>
-                  <div className={styles.characterAvatar}>
-                    {user.selectedCharacter.imageChatAvatar ? (
-                      <img src={user.selectedCharacter.imageChatAvatar} alt="キャラクター" />
-                    ) : (
-                      '🤖'
-                    )}
-                  </div>
-                  <div className={styles.characterInfo}>
-                    <p className={styles.characterName}>
-                      {getSafeString(user.selectedCharacter.name, 'キャラクター')}
-                    </p>
-                    <Link 
-                      href={`/${locale}/setup?reselect=true`}
-                      className={styles.changeCharacter}
-                    >
-                      キャラクター変更
-                    </Link>
-                  </div>
-                </div>
-              ) : (
-                <Link 
-                  href={`/${locale}/setup`}
-                  className={styles.selectCharacter}
-                >
-                  キャラクターを選択
-                </Link>
-              )}
-            </div>
-
-            <div className={styles.section}>
               <h4>チャット機能</h4>
               <div className={styles.actionGrid}>
                 <button className={styles.actionBtn}>💭 新しい会話</button>
@@ -108,6 +75,18 @@ const ContextPanel = ({
                 <button className={styles.actionBtn}>❤️ お気に入り</button>
               </div>
             </div>
+
+            {!user?.selectedCharacter && (
+              <div className={styles.section}>
+                <h4>キャラクター選択</h4>
+                <Link 
+                  href={`/${locale}/setup`}
+                  className={styles.selectCharacter}
+                >
+                  キャラクターを選択
+                </Link>
+              </div>
+            )}
           </>
         );
 

--- a/frontend/app/components/core/TopBar.js
+++ b/frontend/app/components/core/TopBar.js
@@ -118,11 +118,41 @@ const TopBar = ({
           <h1 className={styles.contextTitle}>{contextInfo.title}</h1>
           <p className={styles.contextSubtitle}>{contextInfo.subtitle}</p>
         </div>
+
+        {/* チャット画面でのキャラクター情報と親密度 */}
+        {currentContext === 'chat' && user?.selectedCharacter && (
+          <div className={styles.chatInfo}>
+            <div className={styles.characterAvatar}>
+              {user.selectedCharacter.imageChatAvatar ? (
+                <img 
+                  src={user.selectedCharacter.imageChatAvatar} 
+                  alt={getSafeString(user.selectedCharacter.name, 'キャラクター')}
+                  className={styles.characterImage}
+                />
+              ) : (
+                <span className={styles.characterEmoji}>🤖</span>
+              )}
+            </div>
+            <div className={styles.affinityDisplay}>
+              <div className={styles.affinityLevel}>
+                <span className={styles.affinityLabel}>親密度</span>
+                <span className={styles.affinityValue}>{user.selectedCharacter.affinity || 0}</span>
+                <span className={styles.affinityMax}>/100</span>
+              </div>
+              <div className={styles.affinityBar}>
+                <div 
+                  className={styles.affinityProgress}
+                  style={{ width: `${(user.selectedCharacter.affinity || 0)}%` }}
+                ></div>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
 
-      {/* 中央：管理者向けクイックナビ */}
+      {/* 中央：管理者向けクイックナビ / チャット画面では空 */}
       <div className={styles.centerSection}>
-        {isAdmin && (
+        {isAdmin && currentContext !== 'chat' && (
           <div className={styles.quickNav}>
             <Link href="/admin/dashboard" className={styles.quickNavItem}>
               📊 ダッシュボード

--- a/frontend/app/components/core/TopBar.module.css
+++ b/frontend/app/components/core/TopBar.module.css
@@ -77,6 +77,106 @@
   text-overflow: ellipsis;
 }
 
+/* チャット画面のキャラクター情報と親密度 */
+.chatInfo {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-left: 16px;
+  padding: 8px 12px;
+  background: rgba(248, 250, 252, 0.8);
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  backdrop-filter: blur(8px);
+}
+
+.characterAvatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  flex-shrink: 0;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.characterImage {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.characterEmoji {
+  font-size: 18px;
+  color: white;
+}
+
+.affinityDisplay {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 120px;
+}
+
+.affinityLevel {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+}
+
+.affinityLabel {
+  font-size: 12px;
+  color: #64748b;
+  font-weight: 500;
+}
+
+.affinityValue {
+  font-size: 16px;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.affinityMax {
+  font-size: 12px;
+  color: #94a3b8;
+}
+
+.affinityBar {
+  width: 100%;
+  height: 4px;
+  background: #e2e8f0;
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.affinityProgress {
+  height: 100%;
+  background: linear-gradient(90deg, #ff6b9d, #f8a5c2);
+  border-radius: 2px;
+  transition: width 0.6s ease;
+  position: relative;
+}
+
+.affinityProgress::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.4), transparent);
+  animation: affinityShine 2s ease-in-out infinite;
+}
+
+@keyframes affinityShine {
+  0% { transform: translateX(-100%); }
+  50% { transform: translateX(0%); }
+  100% { transform: translateX(100%); }
+}
+
 /* 中央：ナビゲーション・検索 */
 .centerSection {
   flex: 1;
@@ -307,6 +407,28 @@
   
   .userInfo {
     display: none;
+  }
+
+  .chatInfo {
+    margin-left: 8px;
+    padding: 6px 8px;
+  }
+
+  .characterAvatar {
+    width: 32px;
+    height: 32px;
+  }
+
+  .characterEmoji {
+    font-size: 14px;
+  }
+
+  .affinityDisplay {
+    min-width: 100px;
+  }
+
+  .affinityValue {
+    font-size: 14px;
   }
 }
 


### PR DESCRIPTION
## Summary
- TopBarのチャット画面でキャラクターアイコンと親密度バーを表示
- 情報重複を解消：ContextPanelからキャラクター情報セクションを削除
- チャット機能のみにフォーカスしたサイドパネル設計

## Changes
- TopBar.jsにチャット画面専用のキャラクターアイコンと親密度表示を追加
- ContextPanel.jsからキャラクター情報の重複セクションを削除
- レスポンシブ対応でモバイルでも適切に表示
- 管理者画面ではチャット機能を非表示

## Benefits
- 情報の重複を排除してUIがすっきり
- ヘッダーで常にキャラクター情報と親密度が確認可能
- サイドパネルはチャット機能に特化

## Test plan
- [x] チャット画面でヘッダーにキャラアイコンと親密度が表示される
- [x] ContextPanelからキャラクター情報が削除されている
- [x] キャラクター未選択時は選択リンクのみ表示
- [x] レスポンシブ対応が適切に動作する

🤖 Generated with [Claude Code](https://claude.ai/code)