### PR TITLE
ヘッダーレイアウトを修正：既存構成を維持し親密度を右横に配置

### DIFF
--- a/frontend/app/components/core/TopBar.js
+++ b/frontend/app/components/core/TopBar.js
@@ -162,9 +162,9 @@ const TopBar = ({
           <p className={styles.contextSubtitle}>{contextInfo.subtitle}</p>
         </div>
 
-        {/* チャット画面でのキャラクター情報と親密度 */}
+        {/* チャット画面での親密度表示 */}
         {currentContext === 'chat' && user?.selectedCharacter && (
-          <div className={styles.chatInfo}>
+          <div className={styles.affinitySection}>
             <div className={styles.characterAvatar}>
               {user.selectedCharacter.imageChatAvatar ? (
                 <img 
@@ -176,7 +176,7 @@ const TopBar = ({
                 <span className={styles.characterEmoji}>🤖</span>
               )}
             </div>
-            <div className={styles.affinityContainer}>
+            <div className={styles.affinityDetails}>
               <div className={styles.affinityHeader}>
                 <div className={styles.affinityLevel}>
                   <span className={styles.affinityLabel}>親密度</span>

--- a/frontend/app/components/core/TopBar.module.css
+++ b/frontend/app/components/core/TopBar.module.css
@@ -77,32 +77,27 @@
   text-overflow: ellipsis;
 }
 
-/* チャット画面のキャラクター情報と親密度 */
-.chatInfo {
+/* チャット画面の親密度セクション */
+.affinitySection {
   display: flex;
   align-items: center;
-  gap: 16px;
-  margin-left: 16px;
-  padding: 12px 16px;
-  background: rgba(255, 255, 255, 0.95);
-  border: 1px solid #e2e8f0;
-  border-radius: 16px;
-  backdrop-filter: blur(12px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
-  min-width: 320px;
+  gap: 12px;
+  flex: 1;
+  margin-left: 24px;
+  min-width: 0;
 }
 
 .characterAvatar {
-  width: 48px;
-  height: 48px;
-  border-radius: 12px;
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   display: flex;
   align-items: center;
   justify-content: center;
   overflow: hidden;
   flex-shrink: 0;
-  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
 .characterImage {
@@ -112,15 +107,16 @@
 }
 
 .characterEmoji {
-  font-size: 20px;
+  font-size: 18px;
   color: white;
 }
 
-.affinityContainer {
+.affinityDetails {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
+  min-width: 0;
 }
 
 .affinityHeader {
@@ -169,9 +165,9 @@
 
 .affinityBar {
   flex: 1;
-  height: 6px;
+  height: 8px;
   background: #e2e8f0;
-  border-radius: 3px;
+  border-radius: 4px;
   overflow: hidden;
   box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1);
 }
@@ -179,7 +175,7 @@
 .affinityProgress {
   height: 100%;
   background: linear-gradient(90deg, #ff6b9d, #f8a5c2);
-  border-radius: 3px;
+  border-radius: 4px;
   transition: width 0.8s ease;
   position: relative;
 }
@@ -457,29 +453,27 @@
     display: none;
   }
 
-  .chatInfo {
-    margin-left: 8px;
-    padding: 8px 12px;
-    min-width: 240px;
-    gap: 12px;
+  .affinitySection {
+    margin-left: 12px;
+    gap: 8px;
   }
 
   .characterAvatar {
-    width: 36px;
-    height: 36px;
+    width: 32px;
+    height: 32px;
   }
 
   .characterEmoji {
-    font-size: 16px;
+    font-size: 14px;
   }
 
   .affinityValue {
-    font-size: 16px;
+    font-size: 14px;
   }
 
   .affinityDescription {
-    font-size: 12px;
-    padding: 3px 6px;
+    font-size: 11px;
+    padding: 2px 6px;
   }
 
   .heartsContainer {
@@ -487,8 +481,12 @@
   }
 
   .heartIcon {
-    width: 14px;
-    height: 14px;
+    width: 12px;
+    height: 12px;
+  }
+
+  .affinityBar {
+    height: 6px;
   }
 }
 


### PR DESCRIPTION
## Summary
- contextTitleとcontextSubtitleは元の位置に維持
- 親密度表示をcontextInfoの右横に配置
- 親密度バーが幅いっぱいに広がるレイアウト

## Changes
- TopBar.jsのレイアウト構造を修正
- affinitySectionとaffinityDetailsクラス名に変更
- CSS更新で親密度バーが幅いっぱいに広がるように調整
- キャラクターアイコンと親密度を適切に配置

## Benefits
- 既存のヘッダー構成（contextTitle/Subtitle）を維持
- 親密度バーが画面幅を有効活用
- より自然なレイアウトフロー

## Test plan
- [x] contextTitleとcontextSubtitleが元の位置に表示される
- [x] 親密度がcontextInfoの右横に配置される
- [x] 親密度バーが幅いっぱいに広がる
- [x] レスポンシブ対応が適切に動作する

🤖 Generated with [Claude Code](https://claude.ai/code)