### PR TITLE
キャラクター管理の「サブスク会員用」表記をトークチケット制に統一

### DIFF
--- a/frontend/app/admin/characters/[id]/edit/page.js
+++ b/frontend/app/admin/characters/[id]/edit/page.js
@@ -570,7 +570,7 @@ export default function EditCharacter({ params }) {
                   className={styles.radioInput}
                 />
                 <span className={styles.radioMark}></span>
-                <span className={styles.checkboxLabel}>サブスク会員用キャラクター</span>
+                <span className={styles.checkboxLabel}>有料キャラクター</span>
               </label>
               <label className={styles.customRadio}>
                 <input

--- a/frontend/app/admin/characters/new/page.js
+++ b/frontend/app/admin/characters/new/page.js
@@ -554,7 +554,7 @@ export default function CharacterNewPage() {
                       className={styles.radioInput}
                     />
                     <span className={styles.radioMark}></span>
-                    <span className={styles.checkboxLabel}>サブスク会員用キャラクター</span>
+                    <span className={styles.checkboxLabel}>有料キャラクター</span>
                   </label>
                   <label className={styles.customRadio}>
                     <input


### PR DESCRIPTION
## Summary
キャラクター管理画面の「サブスク会員用キャラクター」表記を「有料キャラクター」に変更し、トークチケット制に合わせた分かりやすい表記に統一しました。

### 変更内容
- **新規作成画面**: 「サブスク会員用キャラクター」→「有料キャラクター」
- **編集画面**: 「サブスク会員用キャラクター」→「有料キャラクター」

### 統一完了
これで管理画面の旧サブスクリプション制表記の統一が完了しました：
- ✅ ユーザー管理画面
- ✅ 管理ダッシュボード  
- ✅ キャラクター管理画面

## Test plan
- [ ] キャラクター新規作成画面で「有料キャラクター」選択肢が表示されることを確認
- [ ] キャラクター編集画面で「有料キャラクター」選択肢が表示されることを確認
- [ ] 機能的に従来と同じ動作をすることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)