### PR TITLE
管理画面の最終ログイン表示をわかりやすく改善

### DIFF
--- a/frontend/app/admin/users/page.js
+++ b/frontend/app/admin/users/page.js
@@ -262,7 +262,7 @@ export default function AdminUsers() {
                           }
                         </div>
                         <div style={{ fontSize: 'var(--admin-font-size-xs)', color: 'var(--admin-gray-400)' }}>
-                          {user.lastLoginAt ? new Date(user.lastLoginAt).toLocaleDateString() : '未記録'}
+                          最終ログイン: {user.lastLoginAt ? new Date(user.lastLoginAt).toLocaleDateString() : '未記録'}
                         </div>
                       </div>
                     </td>
@@ -364,7 +364,7 @@ export default function AdminUsers() {
                       <div style={{ fontSize: 'var(--admin-font-size-sm)', color: 'var(--admin-gray-700)' }}>
                         {selectedUser.lastLoginDate ? new Date(selectedUser.lastLoginDate).toLocaleDateString('ja-JP', {
                           year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit'
-                        }) : '未記録'}
+                        }) : 'データなし'}
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
管理画面ユーザー管理の最終ログイン表示をより分かりやすく改善しました。

### 変更内容
- **テーブル表示**: 単純な「未記録」→「最終ログイン: 未記録」
- **詳細モーダル**: ラベル付きの「未記録」→「データなし」

### 改善効果
- 何のデータが「未記録」なのかが明確になる
- 一目で最終ログイン情報だとわかる
- 統一感のある表示に改善

## Test plan
- [ ] ユーザー管理テーブルで「最終ログイン: 未記録」と表示されることを確認
- [ ] ユーザー詳細モーダルで「データなし」と表示されることを確認
- [ ] 実際にログイン履歴があるユーザーで正常に日付が表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)