### PR TITLE
最終ログインフィールド名の不一致を修正

### DIFF
--- a/frontend/app/admin/users/page.js
+++ b/frontend/app/admin/users/page.js
@@ -262,7 +262,7 @@ export default function AdminUsers() {
                           }
                         </div>
                         <div style={{ fontSize: 'var(--admin-font-size-xs)', color: 'var(--admin-gray-400)' }}>
-                          最終ログイン: {user.lastLoginAt ? new Date(user.lastLoginAt).toLocaleDateString() : '未記録'}
+                          最終ログイン: {user.lastLoginDate ? new Date(user.lastLoginDate).toLocaleDateString() : '未記録'}
                         </div>
                       </div>
                     </td>


### PR DESCRIPTION
## Summary
バックエンドとフロントエンドで最終ログインのフィールド名が不一致だったため、ログイン処理後も「未記録」のままになっていた問題を修正しました。

### 問題
- **バックエンド**: `lastLoginDate` でデータ保存
- **フロントエンド**: `lastLoginAt` で参照 → データが取得できない

### 修正内容
- `lastLoginAt` → `lastLoginDate` に統一
- これで実際のログイン時に最終ログイン日時が正しく表示される

### 影響範囲
- 管理画面ユーザー管理のテーブル表示
- ログイン後に最終ログイン日時が正しく更新表示される

## Test plan
- [ ] ユーザーがログイン後、管理画面で最終ログイン日時が正しく表示されることを確認
- [ ] 新規ユーザーで初回ログイン時にも正しく記録されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)